### PR TITLE
setting the PD to be opt-out, rather than opt-in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@
 #  languages           :string
 #  status              :enum             default("pending"), not null
 #  terms_agreed        :datetime
-#  consider_pd         :boolean          default(FALSE), not null
+#  consider_pd         :boolean          default(TRUE), not null
 #  auth_uid            :string
 #  preferred_editor    :string
 #  terms_seen          :boolean          default(FALSE), not null

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1282,7 +1282,7 @@ CREATE TABLE users (
     languages character varying(255),
     status user_status_enum DEFAULT 'pending'::user_status_enum NOT NULL,
     terms_agreed timestamp without time zone,
-    consider_pd boolean DEFAULT false NOT NULL,
+    consider_pd boolean DEFAULT true: NOT NULL,
     preferred_editor character varying(255),
     terms_seen boolean DEFAULT false NOT NULL,
     auth_uid character varying(255),


### PR DESCRIPTION
Trying to get the PD election to be opt-out, rather than opt-in, to be consistent with pushing as much of OHM as possible into the PD.

1 change: set consider_pd to True in user table in db/structure.sql 
&
1 minor changed: modified a comment reference to the default value in app/models/user.rb

I *believe* this will also set the box on the sign-up form to be checked, but I cannot test to confirm.