### PR TITLE
Update mapstyle to latest, using staging tiles

### DIFF
--- a/app/assets/javascripts/ohm.style.js
+++ b/app/assets/javascripts/ohm.style.js
@@ -103,7 +103,7 @@ ohmStyle = {
             ["stadium", "rgba(208, 220, 174, 1)"],
             ["grass", "rgba(208, 220, 174, 1)"],
             ["grassland", "rgba(208, 220, 174, 1)"],
-            ["garden", "rgba(208, 220, 174, 1)"],
+            ["garden", "rgba(228, 244, 202, 1)"],
             ["village_green", "rgba(208, 220, 174, 1)"],
             ["recreation_ground", "rgba(208, 220, 174, 1)"],
             ["picnic_site", "rgba(208, 220, 174, 1)"],

--- a/app/assets/javascripts/ohm.style.js
+++ b/app/assets/javascripts/ohm.style.js
@@ -1,10 +1,14 @@
 ohmStyle = {
+{
   "version": 8,
   "name": "ohmbasemap",
+  "metadata": {"maputnik:renderer": "mbgljs"},
   "sources": {
     "osm": {
       "type": "vector",
-      "tiles": ["https://vtiles.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf"]
+      "tiles": [
+        "https://vtiles-staging.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf"
+      ]
     }
   },
   "sprite": "https://go-spatial.github.io/carto-assets/spritesets/osm_tegola_spritesheet",
@@ -15,12 +19,8 @@ ohmStyle = {
       "type": "background",
       "minzoom": 0,
       "maxzoom": 20,
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-         "background-color": "rgba(144, 204, 203, 1)"
-      }
+      "layout": {"visibility": "visible"},
+      "paint": {"background-color": "rgba(144, 204, 203, 1)"}
     },
     {
       "id": "land",
@@ -29,29 +29,7 @@ ohmStyle = {
       "source-layer": "land",
       "minzoom": 0,
       "maxzoom": 24,
-      "paint": {
-        "fill-color": "rgba(247, 246, 241, 1)"
-      }
-    },
-    {
-      "id": "pier",
-      "type": "fill",
-      "source": "osm",
-      "source-layer": "other_areas",
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "pier"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(247, 246, 241, 1)"
-      }
+      "paint": {"fill-color": "rgba(247, 246, 241, 1)"}
     },
     {
       "id": "airports",
@@ -60,19 +38,25 @@ ohmStyle = {
       "source-layer": "transport_areas",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "apron"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "apron"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(221, 221, 221, 1)"}
+    },
+    {
+      "id": "landuse_areas_park_overlay",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "landuse_areas",
+      "minzoom": 10,
+      "maxzoom": 24,
+      "layout": {"visibility": "visible"},
       "paint": {
-        "fill-color": "rgba(221, 221, 221, 1)"
+        "fill-color": {
+          "property": "type",
+          "type": "categorical",
+          "default": "transparent",
+          "stops": [["park", "rgba(208, 220, 174, 1)"]]
+        }
       }
     },
     {
@@ -82,168 +66,58 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 13,
       "maxzoom": 24,
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "property": "type",
           "type": "categorical",
-      "default": "transparent",
+          "default": "transparent",
           "stops": [
-           
-            [
-              "wetland",
-              "rgba(227, 233, 226, 1)"
-            ],
-            [
-              "salt_pond",
-              "rgba(236, 240, 241, 1)"
-            ],
-            [
-              "basin",
-              "rgba(144, 204, 203, 1)"
-            ],
-            [
-              "beach",
-              "rgba(238, 229, 178, 1)"
-            ],
-            [
-              "desert",
-              "rgba(238, 229, 178, 1)"
-            ],
-            [
-              "farmland",
-              "rgba(222, 221, 190, 1)"
-            ],
-            [
-              "farm",
-              "rgba(222, 221, 190, 1)"
-            ],
-            [
-              "orchard",
-              "rgba(222, 221, 190, 1)"
-            ],
-            [
-              "allotments",
-              "rgba(222, 221, 190, 1)"
-            ],
-            [
-              "heath",
-              "rgba(225, 233, 214, 1)"
-            ],
-            [
-              "meadow",
-              "rgba(225, 233, 214, 1)"
-            ],
-            [
-              "residential",
-              "rgba(237, 236, 231, 1)"
-            ],
-            [
-              "retail",
-              "rgba(237, 236, 231, 1)"
-            ],
-            [
-              "industrial",
-              "rgba(215, 200, 203, 1)"
-            ],
-            [
-              "quarry",
-              "rgba(215, 200, 203, 1)"
-            ],
-            [
-              "landfill",
-              "rgba(194, 170, 175, 1)"
-            ],
-            [
-              "college",
-              "rgba(226, 214, 205, 1)"
-            ],
-            [
-              "school",
-              "rgba(226, 214, 205, 1)"
-            ],
-            [
-              "education",
-              "rgba(226, 214, 205, 1)"
-            ],
-            [
-              "university",
-              "rgba(226, 214, 205, 1)"
-            ],
-            [
-              "cemetery",
-              "rgba(214, 222, 210, 1)"
-            ],
-            [
-              "grave_yard",
-              "rgba(214, 222, 210, 1)"
-            ],
-            [
-              "park",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "pitch",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "sports_centre",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "stadium",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "grass",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "grassland",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "garden",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "village_green",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "recreation_ground",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "picnic_site",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "camp_site",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "playground",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "forest",
-              "rgba(178, 194, 157, 1)"
-            ],
-            [
-              "wood",
-              "rgba(178, 194, 157, 1)"
-            ],
-            [
-              "nature_reserve",
-              "rgba(178, 194, 157, 0.2)"
-            ],
-            [
-              "commercial",
-              "rgba(215,200,203,1)"
-            ]
+            ["forest", "rgba(178, 194, 157, 1)"],
+            ["wood", "rgba(178, 194, 157, 1)"],
+            ["wetland", "rgba(227, 233, 226, 1)"],
+            ["salt_pond", "rgba(236, 240, 241, 1)"],
+            ["basin", "rgba(144, 204, 203, 1)"],
+            ["beach", "rgba(238, 229, 178, 1)"],
+            ["desert", "rgba(238, 229, 178, 1)"],
+            ["farmland", "rgba(222, 221, 190, 1)"],
+            ["farm", "rgba(222, 221, 190, 1)"],
+            ["orchard", "rgba(222, 221, 190, 1)"],
+            ["allotments", "rgba(222, 221, 190, 1)"],
+            ["heath", "rgba(225, 233, 214, 1)"],
+            ["meadow", "rgba(225, 233, 214, 1)"],
+            ["residential", "rgba(237, 236, 231, 1)"],
+            ["retail", "rgba(237, 236, 231, 1)"],
+            ["industrial", "rgba(230, 206, 206, 1)"],
+            ["quarry", "rgba(215, 200, 203, 1)"],
+            ["landfill", "rgba(194, 170, 175, 1)"],
+            ["college", "rgba(226, 214, 205, 1)"],
+            ["school", "rgba(226, 214, 205, 1)"],
+            ["education", "rgba(226, 214, 205, 1)"],
+            ["university", "rgba(226, 214, 205, 1)"],
+            ["cemetery", "rgba(214, 222, 210, 1)"],
+            ["grave_yard", "rgba(214, 222, 210, 1)"],
+            ["park", "rgba(208, 220, 174, 1)"],
+            ["pitch", "rgba(208, 220, 174, 1)"],
+            ["sports_centre", "rgba(208, 220, 174, 1)"],
+            ["stadium", "rgba(208, 220, 174, 1)"],
+            ["grass", "rgba(208, 220, 174, 1)"],
+            ["grassland", "rgba(208, 220, 174, 1)"],
+            ["garden", "rgba(208, 220, 174, 1)"],
+            ["village_green", "rgba(208, 220, 174, 1)"],
+            ["recreation_ground", "rgba(208, 220, 174, 1)"],
+            ["picnic_site", "rgba(208, 220, 174, 1)"],
+            ["camp_site", "rgba(208, 220, 174, 1)"],
+            ["playground", "rgba(208, 220, 174, 1)"],
+            ["nature_reserve", "rgba(178, 194, 157, 0.2)"],
+            ["commercial", "rgba(215,200,203,1)"],
+            ["construction", "rgba(235, 235, 235, 1)"],
+            ["railway", "rgba(224, 224, 224, 1)"],
+            ["glacier", "rgba(255, 255, 255, 1)"],
+            ["scrub", "rgba(241, 243, 219, 1)"],
+            ["farmyard", "rgba(243, 240, 219, 1)"],
+            ["vineyard", "rgba(230, 224, 241, 1)"],
+            ["brownfield", "rgba(241, 231, 224, 1)"]
           ]
         }
       }
@@ -255,84 +129,34 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 10,
       "maxzoom": 13,
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": {
-          "property": "type",
-          "type": "categorical",
-      "default": "transparent",
-          "stops": [
-            [
-              "park",
-              "rgba(208, 220, 174, 1)"
-            ],
-            [
-              "forest",
-              "rgba(178, 194, 157, 1)"
-            ],
-            [
-              "wood",
-              "rgba(178, 194, 157, 1)"
-            ],
-            [
-              "nature_reserve",
-              "rgba(178, 194, 157, 0.3)"
-            ],
-            [
-              "landfill",
-              "rgba(194, 170, 175, 1)"
-            ]
-          ]
-        }
-      }
-    },
-  {
-      "id": "landuse_areas_park_overlay",
-      "type": "fill",
-      "source": "osm",
-      "source-layer": "landuse_areas",
-      "minzoom": 10,
-      "maxzoom": 24,
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "property": "type",
           "type": "categorical",
           "default": "transparent",
           "stops": [
-            [
-              "park",
-              "rgba(208, 220, 174, 1)"
-            ]
+            ["park", "rgba(208, 220, 174, 1)"],
+            ["forest", "rgba(178, 194, 157, 1)"],
+            ["wood", "rgba(178, 194, 157, 1)"],
+            ["nature_reserve", "rgba(178, 194, 157, 0.3)"],
+            ["landfill", "rgba(194, 170, 175, 1)"]
           ]
         }
       }
     },
-  {
+    {
       "id": "landuse_areas_military_overlay",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "military"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "military"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": "rgba(178, 194, 157, 1)",
-    "fill-pattern": "military-fill"
+        "fill-pattern": "military-fill"
       }
     },
     {
@@ -342,22 +166,9 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 7,
       "maxzoom": 10,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "forest",
-          "wood",
-          "nature_reserve"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(178, 194, 157, 1)"
-      }
+      "filter": ["all", ["in", "type", "forest", "wood", "nature_reserve"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(178, 194, 157, 1)"}
     },
     {
       "id": "landuse_areas_z5",
@@ -368,24 +179,11 @@ ohmStyle = {
       "maxzoom": 7,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "forest",
-          "wood"
-        ],
-        [
-          ">",
-          "area",
-          50000000
-        ]
+        ["in", "type", "forest", "wood"],
+        [">", "area", 50000000]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(178, 194, 157, 1)"
-      }
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(178, 194, 157, 1)"}
     },
     {
       "id": "landuse_areas_z3",
@@ -396,45 +194,20 @@ ohmStyle = {
       "maxzoom": 5,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "forest",
-          "wood"
-        ],
-        [
-          ">",
-          "area",
-          500000000
-        ]
+        ["in", "type", "forest", "wood"],
+        [">", "area", 500000000]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(178, 194, 157, 1)"
-      }
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(178, 194, 157, 1)"}
     },
     {
       "id": "amenity_areas",
       "type": "fill",
       "source": "osm",
       "source-layer": "amenity_areas",
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "school",
-          "university"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(226, 214, 205, 1)"
-      }
+      "filter": ["all", ["in", "type", "school", "university"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(226, 214, 205, 1)"}
     },
     {
       "id": "landuse_naturereserveoutline",
@@ -443,34 +216,11 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "nature_reserve"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "nature_reserve"]],
+      "layout": {"visibility": "visible"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              10,
-              2
-            ],
-            [
-              20,
-              3
-            ]
-          ]
-        },
-        "line-dasharray": [
-          2.5,
-          1.5
-        ],
+        "line-width": {"stops": [[10, 2], [20, 3]]},
+        "line-dasharray": [2.5, 1.5],
         "line-color": "rgba(195, 203, 179, 1)"
       }
     },
@@ -481,58 +231,18 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 4,
       "maxzoom": 10,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "military"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(230, 224, 212, 1)"
-      }
+      "filter": ["all", ["==", "type", "military"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(230, 224, 212, 1)"}
     },
     {
       "id": "military",
       "type": "fill",
       "source": "osm",
       "source-layer": "other_areas",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "military"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(230, 224, 212, 1)"
-      }
-    },
-  {
-      "id": "buildings_flat",
-      "type": "fill",
-      "source": "osm",
-      "source-layer": "buildings",
-      "minzoom": 14,
-      "maxzoom": 24,
-      "filter": [
-        "all"
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(220, 215, 215, 1)",
-        "fill-outline-color": "rgba(195, 188, 188, 1)"
-      }
+      "filter": ["all", ["==", "class", "military"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(230, 224, 212, 1)"}
     },
     {
       "id": "water_lines_stream",
@@ -541,32 +251,10 @@ ohmStyle = {
       "source-layer": "water_lines",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "stream"
-        ]
-      ],
+      "filter": ["all", ["==", "type", "stream"]],
       "paint": {
         "line-color": "rgba(144, 204, 203, 1)",
-        "line-width": {
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              15,
-              0.8
-            ],
-            [
-              20,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[13, 0.5], [15, 0.8], [20, 2]]}
       }
     },
     {
@@ -576,29 +264,10 @@ ohmStyle = {
       "source-layer": "water_lines",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "ditch",
-          "drain"
-        ]
-      ],
+      "filter": ["all", ["in", "type", "ditch", "drain"]],
       "paint": {
         "line-color": "rgba(144, 204, 203, 1)",
-        "line-width": {
-          "stops": [
-            [
-              15,
-              0.2
-            ],
-            [
-              20,
-              1.5
-            ]
-          ]
-        }
+        "line-width": {"stops": [[15, 0.2], [20, 1.5]]}
       }
     },
     {
@@ -608,36 +277,10 @@ ohmStyle = {
       "source-layer": "water_lines",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "canal"
-        ]
-      ],
+      "filter": ["all", ["==", "type", "canal"]],
       "paint": {
         "line-color": "rgba(144, 204, 203, 1)",
-        "line-width": {
-          "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              20,
-              3
-            ]
-          ]
-        }
+        "line-width": {"stops": [[8, 0.5], [13, 0.5], [14, 1], [20, 3]]}
       }
     },
     {
@@ -647,40 +290,10 @@ ohmStyle = {
       "source-layer": "water_lines",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "river"
-        ]
-      ],
+      "filter": ["all", ["==", "type", "river"]],
       "paint": {
         "line-color": "rgba(144, 204, 203, 1)",
-        "line-width": {
-          "stops": [
-            [
-              8,
-              1
-            ],
-            [
-              12,
-              1.5
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              20,
-              12
-            ]
-          ]
-        }
+        "line-width": {"stops": [[8, 1], [12, 1.5], [13, 2], [14, 5], [20, 12]]}
       }
     },
     {
@@ -690,9 +303,8 @@ ohmStyle = {
       "source-layer": "water_areas",
       "minzoom": 5,
       "maxzoom": 24,
-      "paint": {
-        "fill-color": "rgba(144, 204, 203, 1)"
-      }
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(144, 204, 203, 1)"}
     },
     {
       "id": "water_areas_z3",
@@ -701,90 +313,58 @@ ohmStyle = {
       "source-layer": "water_areas",
       "minzoom": 3,
       "maxzoom": 5,
-      "filter": [
-        "all",
-        [
-          ">",
-          "area",
-          1000000000
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": "rgba(144, 204, 203, 1)"
-      }
+      "filter": ["all", [">", "area", 1000000000]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(144, 204, 203, 1)"}
     },
-  {
+    {
+      "id": "pier",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "other_areas",
+      "filter": ["all", ["==", "type", "pier"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(240, 233, 219, 1)"}
+    },
+    {
       "id": "pier_line",
       "type": "line",
       "source": "osm",
       "source-layer": "other_lines",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "pier"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "pier"]],
+      "layout": {"visibility": "visible"},
       "paint": {
-        "line-color": "rgba(247, 246, 241, 1)",
-        "line-width": {
-          "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              18,
-              7
-            ]
-          ]
-        }
+        "line-color": "rgba(230, 222, 205, 1)",
+        "line-width": {"stops": [[12, 2], [18, 7]]}
       }
     },
-  {
+    {
+      "id": "buildings_flat",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "buildings",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": ["all"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(220, 215, 215, 1)",
+        "fill-outline-color": "rgba(195, 188, 188, 1)"
+      }
+    },
+    {
       "id": "aero_taxiway_lines",
       "type": "line",
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "taxiway"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "taxiway"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(220, 220, 220, 1)",
-        "line-width": {
-          "stops": [
-            [
-              12,
-              1
-            ],
-      [
-        13,
-        1.5
-      ],
-            [
-              18,
-              4
-            ]
-          ]
-        }
+        "line-width": {"stops": [[12, 1], [13, 1.5], [18, 4]]}
       }
     },
     {
@@ -794,109 +374,74 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "runway"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "runway"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(220, 220, 220, 1)",
-    "line-width": {
-          "stops": [
-            [
-              12,
-              1.5
-            ],
-            [
-              18,
-              25
-            ]
-          ]
-        }
+        "line-width": {"stops": [[12, 1.5], [18, 25]]}
       }
     },
-  {
+    {
       "id": "city_county_lines",
       "type": "line",
       "source": "osm",
-      "source-layer": "admin_lines",
+      "source-layer": "land_ohm",
       "minzoom": 10,
       "maxzoom": 20,
-    "filter": [
-        "all",
-        [
-          ">=",
-          "admin_level",
-          6
-        ],
-    [
-          "<=",
-          "admin_level",
-          8
-        ]
-    ],  
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", [">=", "admin_level", 6], ["<=", "admin_level", 8]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(210, 210, 210, 1)",
-    "line-dasharray": [
-          2,
-          2
-        ],
-    "line-width": 1.5
+        "line-dasharray": [2, 2],
+        "line-width": 1.5
       }
     },
-  {
+    {
+      "id": "admin5",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "land_ohm",
+      "minzoom": 6,
+      "maxzoom": 20,
+      "filter": ["all", ["==", "admin_level", 5]],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "rgba(179, 179, 179, 1)",
+        "line-dasharray": [2, 2],
+        "line-width": 1.5
+      }
+    },
+    {
       "id": "state_lines_z10",
       "type": "line",
       "source": "osm",
-      "source-layer": "admin_lines",
-      "minzoom": 10,
+      "source-layer": "land_ohm",
+      "minzoom": 2,
       "maxzoom": 20,
-    "filter": [
+      "filter": [
         "all",
-        [
-          "==",
-          "admin_level",
-          4
-        ]
-    ],  
-      "layout": {
-        "visibility": "visible"
-      },
+        ["==", "admin_level", 4],
+        ["==", "type", "administrative"]
+      ],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(178, 171, 171, 1)",
-    "line-dasharray": [
-          6,
-          3
-        ],
-    "line-width": 1.5
+        "line-dasharray": [6, 3],
+        "line-width": 1.5
       }
     },
-  {
+    {
       "id": "state_lines_z2",
       "type": "line",
       "source": "osm",
       "source-layer": "state_lines",
       "minzoom": 2,
       "maxzoom": 10,
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgba(178, 171, 171, 1)",
-    "line-dasharray": [
-          6,
-          3
-        ],
-    "line-width": 1.5
+        "line-dasharray": [6, 3],
+        "line-width": 1.5
       }
     },
     {
@@ -906,31 +451,11 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "track"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "track"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(239, 221, 203, 1)",
-        "line-width": {
-          "stops": [
-            [
-              14,
-              3
-            ],
-            [
-              20,
-              8
-            ]
-          ]
-        }
+        "line-width": {"stops": [[14, 3], [20, 8]]}
       }
     },
     {
@@ -940,31 +465,11 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "track"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "track"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(251, 247, 245, 1)",
-        "line-width": {
-          "stops": [
-            [
-              14,
-              0.5
-            ],
-            [
-              20,
-              3
-            ]
-          ]
-        }
+        "line-width": {"stops": [[14, 0.5], [20, 3]]}
       }
     },
     {
@@ -974,35 +479,12 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "track"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "track"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(218, 191, 164, 1)",
-        "line-dasharray": [
-          0.3,
-          1
-        ],
-        "line-width": {
-          "stops": [
-            [
-              14,
-              3
-            ],
-            [
-              20,
-              8
-            ]
-          ]
-        }
+        "line-dasharray": [0.3, 1],
+        "line-width": {"stops": [[14, 3], [20, 8]]}
       }
     },
     {
@@ -1014,25 +496,13 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "footway",
-          "cycleway",
-          "path",
-          "pedestrian"
-        ]
+        ["in", "type", "footway", "cycleway", "path", "pedestrian"]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(191, 147, 98, 1)",
         "line-width": 1,
-        "line-dasharray": [
-          1,
-          2
-        ]
+        "line-dasharray": [1, 2]
       }
     },
     {
@@ -1042,21 +512,9 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "pier"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-width": 4
-      }
+      "filter": ["all", ["==", "type", "pier"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"line-color": "rgba(255, 255, 255, 1)", "line-width": 4}
     },
     {
       "id": "roads_steps",
@@ -1065,35 +523,12 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "steps"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "steps"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(152, 83, 37, 1)",
-        "line-width": {
-          "stops": [
-            [
-              14,
-              3
-            ],
-            [
-              18,
-              6
-            ]
-          ]
-        },
-        "line-dasharray": [
-          0.1,
-          0.3
-        ]
+        "line-width": {"stops": [[14, 3], [18, 6]]},
+        "line-dasharray": [0.1, 0.3]
       }
     },
     {
@@ -1105,31 +540,12 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "unclassified",
-          "living_street",
-          "raceway"
-        ]
+        ["in", "type", "unclassified", "living_street", "raceway"]
       ],
-      "layout": {
-        "visibility": "none"
-      },
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgba(226, 225, 221, 1)",
-        "line-width": {
-          "stops": [
-            [
-              14,
-              4
-            ],
-            [
-              18,
-              16
-            ]
-          ]
-        }
+        "line-width": {"stops": [[14, 4], [18, 16]]}
       }
     },
     {
@@ -1141,35 +557,12 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "residential",
-          "service",
-          "unclassified"
-        ]
+        ["in", "type", "residential", "service", "unclassified"]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(226, 222, 204, 1)",
-        "line-width": {
-          "stops": [
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              18,
-              10
-            ]
-          ]
-        }
+        "line-width": {"stops": [[13, 2], [14, 3], [18, 10]]}
       }
     },
     {
@@ -1181,35 +574,12 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "residential",
-          "service",
-          "unclassified"
-        ]
+        ["in", "type", "residential", "service", "unclassified"]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(247, 246, 241, 1)",
-        "line-width": {
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              18,
-              6
-            ]
-          ]
-        }
+        "line-width": {"stops": [[13, 0.5], [14, 1], [18, 6]]}
       }
     },
     {
@@ -1221,43 +591,32 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "type",
-          "rail"
-        ],
-        [
-          "!in",
-          "service",
-          "yard",
-          "siding"
-        ]
+        ["==", "type", "rail"],
+        ["!in", "service", "yard", "siding"]
       ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(153, 153, 153, 1)",
-        "line-width": {
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              1.25
-            ],
-            [
-              20,
-              2.25
-            ]
-          ]
-        }
+        "line-width": {"stops": [[12, 1], [13, 1], [14, 1.25], [20, 2.25]]}
+      }
+    },
+    {
+      "id": "roads_rail_cross",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "transport_lines",
+      "minzoom": 12,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        ["==", "type", "rail"],
+        ["!in", "service", "yard", "siding"]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-width": 6,
+        "line-dasharray": [0.2, 2]
       }
     },
     {
@@ -1266,54 +625,19 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "tertiary"
-        ],
-        [
-          "==",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "tertiary"], ["==", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(245, 237, 179, 1)",
         "line-width": {
           "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3.5
-            ],
-            [
-              14,
-              3.5
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
+            [12, 2],
+            [13, 3.5],
+            [14, 3.5],
+            [15, 4],
+            [16, 6],
+            [17, 8],
+            [18, 12]
           ]
         }
       }
@@ -1324,58 +648,20 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "secondary_link"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "secondary_link"], ["!=", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(233, 203, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              9,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [9, 1],
+            [11, 3],
+            [13, 4.5],
+            [14, 6],
+            [15, 7],
+            [16, 9],
+            [17, 10],
+            [18, 14]
           ]
         }
       }
@@ -1386,58 +672,20 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "primary_link"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "primary_link"], ["!=", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(210, 147, 142, 1)",
         "line-width": {
           "stops": [
-            [
-              9,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              3.5
-            ],
-            [
-              14,
-              4.5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              13
-            ]
+            [9, 1],
+            [11, 3],
+            [13, 3.5],
+            [14, 4.5],
+            [15, 6],
+            [16, 10],
+            [17, 11],
+            [18, 13]
           ]
         }
       }
@@ -1451,17 +699,8 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "motorway_link",
-          "trunk_link"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
+        ["in", "type", "motorway_link", "trunk_link"],
+        ["!=", "tunnel", 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1472,34 +711,13 @@ ohmStyle = {
         "line-color": "rgba(160, 152, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 3],
+            [13, 5],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 10],
+            [18, 16]
           ]
         }
       }
@@ -1511,48 +729,11 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "tertiary"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "tertiary"], ["!=", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(214, 224, 152, 1)",
-        "line-width": {
-          "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              18,
-              11
-            ]
-          ]
-        }
+        "line-width": {"stops": [[11, 2], [12, 2], [14, 3], [15, 6], [18, 11]]}
       }
     },
     {
@@ -1561,54 +742,19 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "secondary"
-        ],
-        [
-          "==",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "secondary"], ["==", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(255, 229, 202, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              4.5
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 3],
+            [13, 4.5],
+            [14, 4.5],
+            [15, 5],
+            [16, 8],
+            [17, 10],
+            [18, 14]
           ]
         }
       }
@@ -1619,58 +765,20 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "secondary"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "secondary"], ["!=", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(233, 203, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              9,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [9, 1],
+            [11, 3],
+            [13, 4.5],
+            [14, 6],
+            [15, 7],
+            [16, 9],
+            [17, 10],
+            [18, 14]
           ]
         }
       }
@@ -1681,54 +789,19 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "primary"
-        ],
-        [
-          "==",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "primary"], ["==", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(236, 173, 168, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              4.5
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 3],
+            [13, 4.5],
+            [14, 4.5],
+            [15, 5],
+            [16, 8],
+            [17, 10],
+            [18, 14]
           ]
         }
       }
@@ -1739,93 +812,35 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "primary"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "primary"], ["!=", "tunnel", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(210, 147, 142, 1)",
         "line-width": {
           "stops": [
-            [
-              9,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              3.5
-            ],
-            [
-              14,
-              4.5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              13
-            ]
+            [9, 1],
+            [11, 3],
+            [13, 3.5],
+            [14, 4.5],
+            [15, 6],
+            [16, 10],
+            [17, 11],
+            [18, 13]
           ]
         }
       }
     },
-  {
+    {
       "id": "roads_subways",
       "type": "line",
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 14,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "subway"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "subway"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(153, 153, 153, 1)",
-        "line-width": {
-          "stops": [
-            [
-              14,
-              0.7
-            ],
-            [
-              18,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[14, 0.7], [18, 2]]}
       }
     },
     {
@@ -1837,19 +852,8 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "motorway",
-          "motorway_link",
-          "trunk",
-          "trunk_link"
-        ],
-        [
-          "==",
-          "tunnel",
-          1
-        ]
+        ["in", "type", "motorway", "motorway_link", "trunk", "trunk_link"],
+        ["==", "tunnel", 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1860,34 +864,13 @@ ohmStyle = {
         "line-color": "rgba(186, 178, 202, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 3],
+            [13, 5],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 10],
+            [18, 16]
           ]
         }
       }
@@ -1901,17 +884,8 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "motorway",
-          "trunk"
-        ],
-        [
-          "!=",
-          "tunnel",
-          1
-        ]
+        ["in", "type", "motorway", "trunk"],
+        ["!=", "tunnel", 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1922,34 +896,13 @@ ohmStyle = {
         "line-color": "rgba(160, 152, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 3],
+            [13, 5],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 10],
+            [18, 16]
           ]
         }
       }
@@ -1961,116 +914,39 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 7,
       "maxzoom": 11,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "trunk",
-      "primary"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "trunk", "primary"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(160, 152, 176, 1)",
-        "line-width": {
-          "stops": [
-            [
-              7,
-              0.3
-            ],
-            [
-              8,
-              0.5
-            ],
-            [
-              10,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[7, 0.3], [8, 0.5], [10, 2]]}
       }
     },
-  {
+    {
       "id": "roads_motorway_z7",
       "type": "line",
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 7,
       "maxzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "motorway"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "motorway"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(160, 152, 176, 1)",
-        "line-width": {
-          "stops": [
-            [
-              7,
-              0.6
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              10,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[7, 0.6], [8, 1], [10, 2]]}
       }
     },
-  {
+    {
       "id": "roads_motorway_z4_minzoom",
       "type": "line",
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 4,
       "maxzoom": 8,
-      "filter": [
-        "all",
-    [
-          ">",
-          "min_zoom",
-      5
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", [">", "min_zoom", 5]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(224, 221, 224, 1)",
-        "line-width": {
-          "stops": [
-            [
-              4,
-              0.8
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              10,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[4, 0.8], [7, 1], [8, 1], [10, 2]]}
       }
     },
     {
@@ -2080,39 +956,11 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 4,
       "maxzoom": 8,
-      "filter": [
-        "all",
-    [
-          "<=",
-          "min_zoom",
-      5
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["<=", "min_zoom", 5]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(160, 152, 176, 1)",
-        "line-width": {
-          "stops": [
-            [
-              4,
-              0.5
-            ],
-            [
-              7,
-              0.6
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              10,
-              2
-            ]
-          ]
-        }
+        "line-width": {"stops": [[4, 0.5], [7, 0.6], [8, 1], [10, 2]]}
       }
     },
     {
@@ -2121,54 +969,19 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "tertiary"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "tertiary"], ["==", "bridge", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(169, 161, 103, 1)",
         "line-width": {
           "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3.5
-            ],
-            [
-              14,
-              3.5
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
+            [12, 2],
+            [13, 3.5],
+            [14, 3.5],
+            [15, 4],
+            [16, 6],
+            [17, 8],
+            [18, 12]
           ]
         }
       }
@@ -2180,48 +993,11 @@ ohmStyle = {
       "source-layer": "transport_lines",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "tertiary"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "tertiary"], ["==", "bridge", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(214, 224, 152, 1)",
-        "line-width": {
-          "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              18,
-              11
-            ]
-          ]
-        }
+        "line-width": {"stops": [[11, 2], [12, 2], [14, 3], [15, 6], [18, 11]]}
       }
     },
     {
@@ -2229,54 +1005,19 @@ ohmStyle = {
       "type": "line",
       "source": "osm",
       "source-layer": "transport_lines",
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "secondary"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "secondary"], ["==", "bridge", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(183, 153, 126, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              8
-            ],
-            [
-              15,
-              10
-            ],
-            [
-              16,
-              12
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [11, 3],
+            [13, 4.5],
+            [14, 8],
+            [15, 10],
+            [16, 12],
+            [17, 14],
+            [18, 18]
           ]
         }
       }
@@ -2287,54 +1028,19 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "secondary"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "type", "secondary"], ["==", "bridge", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(233, 203, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 3],
+            [13, 4.5],
+            [14, 6],
+            [15, 7],
+            [16, 9],
+            [17, 10],
+            [18, 14]
           ]
         }
       }
@@ -2348,54 +1054,21 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "primary",
-          "primary_link"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
+        ["in", "type", "primary", "primary_link"],
+        ["==", "bridge", 1]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "visibility": "visible"
-      },
+      "layout": {"line-cap": "butt", "visibility": "visible"},
       "paint": {
         "line-color": "rgba(160, 97, 92, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4.5
-            ],
-            [
-              14,
-              8
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              12
-            ],
-            [
-              17,
-              15
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 3],
+            [13, 4.5],
+            [14, 8],
+            [15, 9],
+            [16, 12],
+            [17, 15],
+            [18, 16]
           ]
         }
       }
@@ -2406,58 +1079,20 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "primary"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["in", "type", "primary"], ["==", "bridge", 1]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(210, 147, 142, 1)",
         "line-width": {
           "stops": [
-            [
-              9,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              3.5
-            ],
-            [
-              14,
-              4.5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              13
-            ]
+            [9, 1],
+            [11, 3],
+            [13, 3.5],
+            [14, 4.5],
+            [15, 6],
+            [16, 10],
+            [17, 11],
+            [18, 13]
           ]
         }
       }
@@ -2471,19 +1106,8 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "motorway",
-          "motorway_link",
-          "trunk",
-          "trunk_link"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
+        ["in", "type", "motorway", "motorway_link", "trunk", "trunk_link"],
+        ["==", "bridge", 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2494,34 +1118,13 @@ ohmStyle = {
         "line-color": "rgba(110, 102, 126, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              10
-            ],
-            [
-              16,
-              12
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              20
-            ]
+            [11, 3],
+            [13, 5],
+            [14, 7],
+            [15, 10],
+            [16, 12],
+            [17, 14],
+            [18, 20]
           ]
         }
       }
@@ -2535,19 +1138,8 @@ ohmStyle = {
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "motorway",
-          "motorway_link",
-          "trunk",
-          "trunk_link"
-        ],
-        [
-          "==",
-          "bridge",
-          1
-        ]
+        ["in", "type", "motorway", "motorway_link", "trunk", "trunk_link"],
+        ["==", "bridge", 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2558,69 +1150,66 @@ ohmStyle = {
         "line-color": "rgba(160, 152, 176, 1)",
         "line-width": {
           "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 3],
+            [13, 5],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 10],
+            [18, 16]
           ]
         }
       }
     },
-  {
+    {
+      "id": "man_made_bridge_area",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "other_areas",
+      "filter": ["all", ["==", "class", "man_made"], ["==", "type", "bridge"]],
+      "paint": {"fill-color": "rgba(233, 203, 176, 1)"}
+    },
+    {
+      "id": "man_made_bridge_line",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "other_lines",
+      "filter": ["all", ["==", "class", "man_made"], ["==", "type", "bridge"]],
+      "paint": {"line-color": "rgba(233, 203, 176, 1)", "line-width": 3}
+    },
+    {
+      "id": "pedestrian_area",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "paint": {"fill-color": "rgba(230, 230, 230, 1)"}
+    },
+    {
+      "id": "admin_admin3_z10",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "land_ohm",
+      "minzoom": 2,
+      "maxzoom": 20,
+      "filter": ["all", ["==", "admin_level", 3]],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "line-color": "rgba(181, 195, 199, 1)",
+        "line-width": {"stops": [[0, 0.25], [7, 2]]}
+      }
+    },
+    {
       "id": "admin_countrylines_z10",
       "type": "line",
       "source": "osm",
-      "source-layer": "admin_lines",
-      "minzoom": 10,
+      "source-layer": "land_ohm",
+      "minzoom": 0,
       "maxzoom": 20,
-    "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ]
-    ],  
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "admin_level", 2]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "line-color": "rgba(129, 150, 154, 1)",
-    "line-width": {
-      "stops": [
-        [ 0,
-        0.5
-        ],
-        [
-        7,
-        3
-        ]
-      ]
-    } 
+        "line-width": {"stops": [[0, 0.5], [7, 3]]}
       }
     },
     {
@@ -2630,22 +1219,10 @@ ohmStyle = {
       "source-layer": "country_lines",
       "minzoom": 0,
       "maxzoom": 10,
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "none"},
       "paint": {
         "line-color": "rgba(129, 150, 154, 1)",
-    "line-width": {
-      "stops": [
-        [ 0,
-        0.5
-        ],
-        [
-        7,
-        3
-        ]
-      ]
-    } 
+        "line-width": {"stops": [[0, 0.5], [7, 3]]}
       }
     },
     {
@@ -2654,35 +1231,18 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 14,
-      "filter": [
-        "!=",
-        "type",
-        "subway"
-      ],
+      "filter": ["!=", "type", "subway"],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
         "symbol-spacing": 250,
         "symbol-avoid-edges": false,
-        "text-size": {
-          "stops": [
-            [
-              13,
-              10
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        },
+        "text-size": {"stops": [[13, 10], [20, 18]]},
         "text-padding": 2,
         "text-allow-overlap": false,
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "text-font": [
-          "Open Sans Regular"
-        ]
+        "text-font": ["Open Sans Regular"]
       },
       "paint": {
         "text-color": "rgba(82, 82, 82, 1)",
@@ -2696,15 +1256,7 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "transport_lines",
       "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "motorway",
-          "trunk"
-        ]
-      ],
+      "filter": ["all", ["in", "type", "motorway", "trunk"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -2715,9 +1267,7 @@ ohmStyle = {
         "text-allow-overlap": false,
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "text-font": [
-          "Open Sans Regular"
-        ]
+        "text-font": ["Open Sans Regular"]
       },
       "paint": {
         "text-color": "rgba(82, 82, 82, 1)",
@@ -2732,33 +1282,13 @@ ohmStyle = {
       "source-layer": "water_areas",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          ">",
-          "area",
-          100000
-        ]
-      ],
+      "filter": ["all", [">", "area", 100000]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Open Sans Italic"
-        ],
+        "text-font": ["Open Sans Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
-        "text-size": {
-          "stops": [
-            [
-              15,
-              11
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
+        "text-size": {"stops": [[15, 11], [20, 20]]}
       },
       "paint": {
         "text-color": "rgba(68, 136, 136, 1)",
@@ -2773,37 +1303,13 @@ ohmStyle = {
       "source-layer": "water_areas",
       "minzoom": 12,
       "maxzoom": 15,
-      "filter": [
-        "all",
-        [
-          ">",
-          "area",
-          1000000
-        ]
-      ],
+      "filter": ["all", [">", "area", 1000000]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Open Sans Italic"
-        ],
+        "text-font": ["Open Sans Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
-        "text-size": {
-          "stops": [
-            [
-              12,
-              10
-            ],
-            [
-              15,
-              11
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
+        "text-size": {"stops": [[12, 10], [15, 11], [20, 20]]}
       },
       "paint": {
         "text-color": "rgba(68, 136, 136, 1)",
@@ -2818,37 +1324,13 @@ ohmStyle = {
       "source-layer": "water_areas",
       "minzoom": 8,
       "maxzoom": 12,
-      "filter": [
-        "all",
-        [
-          ">",
-          "area",
-          10000000
-        ]
-      ],
+      "filter": ["all", [">", "area", 10000000]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Open Sans Italic"
-        ],
+        "text-font": ["Open Sans Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              15,
-              11
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
+        "text-size": {"stops": [[8, 8], [15, 11], [20, 20]]}
       },
       "paint": {
         "text-color": "rgba(68, 136, 136, 1)",
@@ -2863,24 +1345,11 @@ ohmStyle = {
       "source-layer": "water_lines",
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Open Sans Italic"
-        ],
+        "text-font": ["Open Sans Italic"],
         "symbol-placement": "line",
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
-        "text-size": {
-          "stops": [
-            [
-              11,
-              11
-            ],
-            [
-              13,
-              13
-            ]
-          ]
-        },
+        "text-size": {"stops": [[11, 11], [13, 13]]},
         "text-anchor": "bottom",
         "text-letter-spacing": 0
       },
@@ -2916,16 +1385,9 @@ ohmStyle = {
           "camp_site",
           "playground"
         ],
-        [
-          ">",
-          "area",
-          12000
-        ]
+        [">", "area", 12000]
       ],
-      "layout": {
-        "text-field": "{name}",
-        "text-size": 11
-      },
+      "layout": {"text-field": "{name}", "text-size": 11},
       "paint": {
         "text-color": "rgba(122, 143, 61, 1)",
         "text-halo-color": "rgba(228, 235, 209, 1)",
@@ -2939,20 +1401,8 @@ ohmStyle = {
       "source-layer": "landuse_areas",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "type",
-          "forest",
-          "wood",
-          "nature_reserve"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-size": 11
-      },
+      "filter": ["all", ["in", "type", "forest", "wood", "nature_reserve"]],
+      "layout": {"text-field": "{name}", "text-size": 11},
       "paint": {
         "text-color": "rgba(95, 107, 71, 1)",
         "text-halo-color": "rgba(201, 213, 190, 1)",
@@ -2968,335 +1418,224 @@ ohmStyle = {
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "type",
-          "college",
-          "school",
-          "education",
-          "university",
-          ""
-        ]
+        ["in", "type", "college", "school", "education", "university", ""]
       ],
-      "layout": {
-        "text-field": "{name}",
-        "text-size": 11
-      },
+      "layout": {"text-field": "{name}", "text-size": 11},
       "paint": {
         "text-color": "rgba(176, 130, 130, 1)",
         "text-halo-color": "rgba(245, 239, 239, 1)",
         "text-halo-width": 1
       }
     },
-  {
+    {
       "id": "city_labels_z14",
       "type": "symbol",
       "source": "osm",
-      "source-layer": "admin_lines",
+      "source-layer": "place_points",
       "minzoom": 14,
       "maxzoom": 20,
-    "filter": [
+      "filter": [
         "all",
-    [
-          "==",
-          "admin_level",
-          8
-        ]
-    ],  
-       "layout": {
+        ["==", "type", "city"],
+        ["==", "type", "suburb"],
+        ["==", "type", "town"],
+        ["==", "type", "village"],
+        ["==", "type", "locality"],
+        ["==", "type", "hamlet"]
+      ],
+      "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Regular"
-        ],
-    "text-size": 10,
-    "text-transform": "uppercase",
-    "text-letter-spacing": 0.5
+        "text-font": ["Open Sans Regular"],
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.5,
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(34, 34, 34, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "city_labels_z12",
       "type": "symbol",
       "source": "osm",
-      "source-layer": "populated_places",
+      "source-layer": "place_points",
       "minzoom": 12,
       "maxzoom": 14,
-    "filter": [
+      "filter": [
         "all",
-        [
-          "==",
-          "featurecla",
-          "Populated place"
-        ]
+        ["==", "type", "city"],
+        ["==", "type", "village"],
+        ["==", "type", "town"],
+        ["==", "type", "suburb"],
+        ["==", "type", "locality"],
+        ["==", "type", "hamlet"]
       ],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Regular"
-        ],
-    "text-size": 10,
-    "text-transform": "uppercase",
-    "text-letter-spacing": 0.5
+        "text-font": ["Open Sans Regular"],
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.5,
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(34, 34, 34, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "city_labels_z6",
       "type": "symbol",
       "source": "osm",
-      "source-layer": "populated_places",
+      "source-layer": "place_points",
       "minzoom": 6,
       "maxzoom": 12,
-    "filter": [
-        "all",
-        [
-          "==",
-          "featurecla",
-          "Populated place"
-        ]
-      ],
+      "filter": ["all", ["==", "type", "city"]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Regular"
-        ],
-    "text-size": 10
+        "text-font": ["Open Sans Regular"],
+        "text-size": 10,
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(34, 34, 34, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "state_labels",
       "type": "symbol",
       "source": "osm",
       "source-layer": "state_label_points",
       "minzoom": 5,
       "maxzoom": 10,
-    "filter": [
-        "all",
-        [
-          "==",
-          "scalerank",
-          2
-        ]
-      ],
+      "filter": ["all", ["==", "scalerank", 2]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Bold Italic"
-        ],
-    "text-size": {
-      "stops": [
-            [
-              4,
-              7
-            ],
-            [
-              10,
-              16
-            ]
-          ]
-    }  
+        "text-font": ["Open Sans Bold Italic"],
+        "text-size": {"stops": [[4, 7], [10, 16]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(166, 166, 170, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "statecapital_labels_z10",
       "type": "symbol",
       "source": "osm",
       "source-layer": "populated_places",
       "minzoom": 10,
       "maxzoom": 20,
-    "filter": [
-        "all",
-        [
-          "==",
-          "featurecla",
-          "Admin-1 capital"
-        ]
-      ],
+      "filter": ["all", ["==", "featurecla", "Admin-1 capital"]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Bold"
-        ],
-    "text-size": 10,
-    "text-transform": "uppercase"
+        "text-font": ["Open Sans Bold"],
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(68, 51, 85, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "statecapital_labels_z4",
       "type": "symbol",
       "source": "osm",
       "source-layer": "populated_places",
       "minzoom": 4,
       "maxzoom": 10,
-    "filter": [
-        "all",
-        [
-          "==",
-          "featurecla",
-          "Admin-1 capital"
-        ]
-      ],
+      "filter": ["all", ["==", "featurecla", "Admin-1 capital"]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Bold"
-        ],
-    "text-size": {
-      "stops": [
-            [
-              4,
-              7
-            ],
-            [
-              10,
-              10
-            ]
-          ]
-    }  
+        "text-font": ["Open Sans Bold"],
+        "text-size": {"stops": [[4, 7], [10, 10]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(68, 51, 85, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "capital_labels_z10",
       "type": "symbol",
       "source": "osm",
       "source-layer": "populated_places",
       "minzoom": 10,
       "maxzoom": 20,
-    "filter": [
-        "all",
-        [
-          "==",
-          "featurecla",
-          "Admin-0 capital"
-        ]
-      ],
+      "filter": ["all", ["==", "featurecla", "Admin-0 capital"]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Bold"
-        ],
-    "text-size": 11,
-    "text-transform": "uppercase"
+        "text-font": ["Open Sans Bold"],
+        "text-size": 11,
+        "text-transform": "uppercase",
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(68, 51, 85, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "capital_labels_z3",
       "type": "symbol",
       "source": "osm",
       "source-layer": "populated_places",
       "minzoom": 3,
       "maxzoom": 10,
-    "filter": [
-        "all",
-        [
-          "==",
-          "featurecla",
-          "Admin-0 capital"
-        ]
-      ],
+      "filter": ["all", ["==", "featurecla", "Admin-0 capital"]],
       "layout": {
         "text-field": "{name}",
-    "text-font": [
-          "Open Sans Bold"
-        ],
-    "text-size": {
-      "stops": [
-            [
-              3,
-              9
-            ],
-            [
-              10,
-              11
-            ]
-          ]
-    }  
+        "text-font": ["Open Sans Bold"],
+        "text-size": {"stops": [[3, 9], [10, 11]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(68, 51, 85, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 1
+        "text-halo-blur": 1
       }
     },
-  {
+    {
       "id": "country_labels",
       "type": "symbol",
       "source": "osm",
       "source-layer": "country_label_points",
       "minzoom": 3,
       "maxzoom": 7,
-    "filter": [
-        "all",
-        [
-          "==",
-          "scalerank",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "scalerank", 0]],
       "layout": {
         "text-field": "{sr_subunit}",
-    "text-font": [
-          "Open Sans Bold"
-        ],
-        "text-size": {
-      "stops": [
-            [
-              3,
-              11
-            ],
-            [
-              7,
-              13
-            ]
-          ]
-    }  
+        "text-font": ["Open Sans Bold"],
+        "text-size": {"stops": [[3, 11], [7, 13]]},
+        "visibility": "none"
       },
       "paint": {
         "text-color": "rgba(68, 51, 85, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1,
-    "text-halo-blur": 5
+        "text-halo-blur": 5
       }
     },
     {
@@ -3304,21 +1643,48 @@ ohmStyle = {
       "type": "line",
       "source": "osm",
       "source-layer": "other_lines",
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "power"
-        ],
-        [
-          "==",
-          "type",
-          "line"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "power"], ["==", "type", "line"]],
+      "layout": {"visibility": "visible"},
+      "paint": {"line-color": "rgba(164, 129, 136, 1)"}
+    },
+    {
+      "id": "barriers-dotted",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "other_lines",
+      "filter": ["all"],
       "paint": {
-        "line-color": "rgba(164, 129, 136, 1)"
+        "line-color": {
+          "property": "type",
+          "type": "categorical",
+          "stops": [["bollard", "rgba(217, 217, 217, 1)"]],
+          "default": "transparent"
+        },
+        "line-width": 3,
+        "line-dasharray": [1, 1]
+      }
+    },
+    {
+      "id": "barriers",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "other_lines",
+      "filter": ["all"],
+      "paint": {
+        "line-color": {
+          "property": "type",
+          "type": "categorical",
+          "stops": [
+            ["wall", "rgba(223, 223, 223, 1)"],
+            ["fence", "rgba(233, 228, 216, 1)"],
+            ["wood_fence", "rgba(241, 224, 200, 1)"],
+            ["hedge", "rgba(204, 218, 190, 1)"],
+            ["hedge_bank", "rgba(204, 218, 190, 1)"],
+            ["retaining_wall", "rgba(223, 223, 223, 1)"]
+          ],
+          "default": "transparent"
+        },
+        "line-width": 2
       }
     },
     {
@@ -3328,12 +1694,8 @@ ohmStyle = {
       "source-layer": "transport_points",
       "minzoom": 16,
       "maxzoom": 24,
-      "layout": {
-        "icon-image": "{type}-18"
-      },
-      "paint": {
-        "icon-color": "rgba(12, 9, 9, 1)"
-      }
+      "layout": {"icon-image": "{type}-18"},
+      "paint": {"icon-color": "rgba(12, 9, 9, 1)"}
     },
     {
       "id": "points_of_interest_frombuildings",
@@ -3341,23 +1703,14 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "buildings",
       "minzoom": 16,
-      "filter": [
-        "all",
-        [
-          "has",
-          "tourism"
-        ]
-      ],
+      "filter": ["all", ["has", "tourism"]],
       "layout": {
         "icon-image": "{tourism}-18",
         "visibility": "visible",
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3397,10 +1750,7 @@ ohmStyle = {
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3416,19 +1766,14 @@ ohmStyle = {
       "source-layer": "amenity_areas",
       "minzoom": 16,
       "maxzoom": 24,
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3468,10 +1813,7 @@ ohmStyle = {
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3487,19 +1829,14 @@ ohmStyle = {
       "source-layer": "amenity_points",
       "minzoom": 16,
       "maxzoom": 24,
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3515,17 +1852,8 @@ ohmStyle = {
       "source-layer": "other_points",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "tower"
-        ]
-      ],
-      "layout": {
-        "icon-image": "power_tower-12"
-      }
+      "filter": ["all", ["==", "type", "tower"]],
+      "layout": {"icon-image": "power_tower-12"}
     },
     {
       "id": "points_airport",
@@ -3534,17 +1862,8 @@ ohmStyle = {
       "source-layer": "transport_areas",
       "minzoom": 10,
       "maxzoom": 14,
-      "filter": [
-        "all",
-        [
-          "==",
-          "type",
-          "aerodrome"
-        ]
-      ],
-      "layout": {
-        "icon-image": "airport-18"
-      }
+      "filter": ["all", ["==", "type", "aerodrome"]],
+      "layout": {"icon-image": "airport-18"}
     },
     {
       "id": "points_placeofworshipother",
@@ -3553,34 +1872,18 @@ ohmStyle = {
       "source-layer": "buildings",
       "filter": [
         "all",
-        [
-          "==",
-          "type",
-          "place_of_worship"
-        ],
-        [
-          "!in",
-          "religion",
-          "christian",
-          "muslim",
-          "jewish"
-        ]
+        ["==", "type", "place_of_worship"],
+        ["!in", "religion", "christian", "muslim", "jewish"]
       ],
-      "layout": {
-        "icon-image": "place_of_worship-18"
-      }
+      "layout": {"icon-image": "place_of_worship-18"}
     },
     {
       "id": "points_religion",
       "type": "symbol",
       "source": "osm",
       "source-layer": "buildings",
-      "filter": [
-        "all"
-      ],
-      "layout": {
-        "icon-image": "{religion}-18"
-      }
+      "filter": ["all"],
+      "layout": {"icon-image": "{religion}-18"}
     },
     {
       "id": "points_fromlanduseareas",
@@ -3588,27 +1891,15 @@ ohmStyle = {
       "source": "osm",
       "source-layer": "landuse_areas",
       "minzoom": 16,
-      "layout": {
-        "icon-image": "{type}-18"
-      }
+      "layout": {"icon-image": "{type}-18"}
     },
     {
       "id": "points_acra",
       "type": "symbol",
       "source": "osm",
       "source-layer": "buildings",
-      "filter": [
-        "all",
-        [
-          "in",
-          "name",
-          "ACRA",
-          "Acra"
-        ]
-      ],
-      "layout": {
-        "icon-image": "acra-18"
-      }
+      "filter": ["all", ["in", "name", "ACRA", "Acra"]],
+      "layout": {"icon-image": "acra-18"}
     },
     {
       "id": "points_oxfam",
@@ -3648,9 +1939,7 @@ ohmStyle = {
           "Oxfam books"
         ]
       ],
-      "layout": {
-        "icon-image": "oxfam-18"
-      }
+      "layout": {"icon-image": "oxfam-18"}
     },
     {
       "id": "points_of_interest_shop",
@@ -3659,23 +1948,14 @@ ohmStyle = {
       "source-layer": "buildings",
       "minzoom": 16,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "has",
-          "shop"
-        ]
-      ],
+      "filter": ["all", ["has", "shop"]],
       "layout": {
         "icon-image": "{shop}-18",
         "visibility": "visible",
         "text-field": "{name}",
         "text-size": 8,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          1
-        ]
+        "text-offset": [0, 1]
       },
       "paint": {
         "text-color": "rgba(108, 132, 137, 1)",
@@ -3684,5 +1964,6 @@ ohmStyle = {
         "text-halo-blur": 1
       }
     }
-  ]
+  ],
+  "id": "io6r61fxt"
 };


### PR DESCRIPTION
As tested at https://openhistoricalmap.github.io/map-styles/demo.html. As we discussed just now, this is still pointing at https://vtiles-staging.openhistoricalmap.org. Once merged to staging, then you can update this line for merging into Production: https://github.com/OpenHistoricalMap/ohm-website/blob/staging/app/assets/javascripts/ohm.style.js#L7