### PR TITLE
dont secure cookies because aws alb doesnt support

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Based on https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html -- this removes cookie secure flag so ALB doesn't drop them.

cc @batpad 