### PR TITLE
ohmStyle use production or staging tiles based on URL hostname or params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ohm-docker.env
 log
 config/piwik.yml
 app/assets/javascripts/i18n

--- a/app/assets/javascripts/ohm.style.js
+++ b/app/assets/javascripts/ohm.style.js
@@ -1,11 +1,27 @@
-ohmStyle = {
+// two sets of vector tiles: staging & production
+// to use staging, either point yourt browser at http://localhost/ or else set &stagingtiles=1 in your URL params
+
+const ohmTileServiceName = window.location.hostname.toLowerCase() == 'localhost' || window.location.hash.indexOf('stagingtiles=1') !== 0 ? 'staging' : 'production';
+
+const ohmTileServicesLists = {
+  "production": [
+    "https://vtiles.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf",
+  ],
+  "staging": [
+    "https://vtiles-staging.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf",
+  ],
+};
+
+const ohmTileServicesList = ohmTileServicesLists[ohmTileServiceName];
+
+const ohmStyle = {
   "version": 8,
   "name": "ohmbasemap",
   "metadata": {"maputnik:renderer": "mbgljs"},
   "sources": {
     "osm": {
       "type": "vector",
-      "tiles": ["https://vtiles-staging.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf"]
+      "tiles": ohmTileServicesList,
     }
   },
   "sprite": "https://go-spatial.github.io/carto-assets/spritesets/osm_tegola_spritesheet",

--- a/app/assets/javascripts/ohm.style.js
+++ b/app/assets/javascripts/ohm.style.js
@@ -1,7 +1,7 @@
 // two sets of vector tiles: staging & production
 // to use staging, either point yourt browser at http://localhost/ or else set &stagingtiles=1 in your URL params
 
-const ohmTileServiceName = window.location.hostname.toLowerCase() == 'localhost' || window.location.hash.indexOf('stagingtiles=1') !== 0 ? 'staging' : 'production';
+const ohmTileServiceName = window.location.hostname.toLowerCase() == 'localhost' || window.location.hostname.toLowerCase() == 'staging.openhistoricalmap.org' || window.location.hash.indexOf('stagingtiles=1') !== 0 ? 'staging' : 'production';
 
 const ohmTileServicesLists = {
   "production": [


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/104

The `ohmStyle.sources.osm.tiles` will now be set to either staging or production URLs, based on the hostname being localhost and/or a `&stagingtiles=1` URL param.