### PR TITLE
add ohm-docker.env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ohm-docker.env
 log
 config/piwik.yml
 app/assets/javascripts/i18n


### PR DESCRIPTION
The **ohm-docker.env** file contains credentials, and should not be added to version control. This adds it to gitignore so one can't accidentally add it.
