### PR TITLE
improve behavior of timeslider under changing conditions

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -414,9 +414,6 @@ $(document).ready(function () {
   // Define the slider options: default date and min/max date allowable
   // params come from mapParams() which sets defaults for the map etc.
   var historicalLayerKey = 'historical';
-  var ohmLayer = map._layers[Object.keys(map._layers).filter(function(id) {
-    return map._layers[id].options.keyid === historicalLayerKey;
-  })[0]];
 
   var timeSliderHardMaxYear = (new Date()).getFullYear();  // current calendar year
   var timeSliderHardMinYear = -4000;
@@ -424,7 +421,7 @@ $(document).ready(function () {
 
   var sliderOptions = {
     position: 'bottomright',
-    mbgllayer: ohmLayer,
+    mbgllayer: undefined,  // see addTimeSliderToMap() whichy searches for this
     timeSliderOptions: {
       sourcename: "osm",
       date: parseInt(params.date),
@@ -442,15 +439,39 @@ $(document).ready(function () {
     }
   };
 
-  // Add the slider
-  // Detect when the baseLayer is changed, and add the slider back in (or store its last state)
-  map.timeslider = new L.Control.MBGLTimeSlider(sliderOptions).addTo(map);
+  // add the slider IF the the OSM vector map is the layer showing
+  if (getHistoryLayerIfShowing()) {
+    addTimeSliderToMap(sliderOptions);
+  }
 
-  map.on('baselayerchange', function(e) {
-    sliderOptions.timeSliderOptions.date = this.timeslider._timeslider._current_date;
-    if (e.layer.options.keyid === historicalLayerKey) {
-      this.timeslider = new L.Control.MBGLTimeSlider(sliderOptions).addTo(map);
+  // when we change to a different basemap, the timeslider (which itself is a MBGL control, the layer is a MBGL map) disappears
+  // fortunately map.timeslider is still defined so we can refer to it for values,
+  // create a new one, and add it to the map
+  map.on('baselayerchange', function () {
+    const usetheslider = getHistoryLayerIfShowing();
+    if (! usetheslider) return;
+
+    const newSliderOptions = Object.assign({}, sliderOptions);
+    if (this.timeslider) {
+      newSliderOptions.timeSliderOptions.date = this.timeslider.getDate();
+      newSliderOptions.timeSliderOptions.range = this.timeslider.getRange();
     }
+    addTimeSliderToMap(newSliderOptions);
   });
 
+  // the wrapper function to add the slider to the map
+  // because we need to search for ohmLayer
+  // which will exist & vanish as the basemap changes and when page is first loaded
+  function getHistoryLayerIfShowing () {
+    let ohmlayer;
+    map.eachLayer(function (layer) {
+      if (layer.options.keyid === historicalLayerKey) ohmlayer = layer;
+    });
+    return ohmlayer;
+  }
+  function addTimeSliderToMap (slideroptions) {
+    const ohmlayer = getHistoryLayerIfShowing();
+    slideroptions.mbgllayer = ohmlayer;
+    map.timeslider = new L.Control.MBGLTimeSlider(slideroptions).addTo(map);
+  }
 });


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/108

This change improves the behavior of the timeslider under varying, changing conditions:
* page loads with another layer selected: open with Humanitarian, TS will still be added when changing over to Historical
* TS min/max/date preserved when changing to other maps and back again
* TS min/max/date even reinstated when the page starts with another layer open

