### PR TITLE
on page load, zoom to feature

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -335,8 +335,8 @@ $(document).ready(function () {
 
     function addObject(type, id, center) {
       map.addObject({type: type, id: parseInt(id)}, function(bounds) {
-        if (!window.location.hash && bounds.isValid() &&
-            (center || !map.getBounds().contains(bounds))) {
+        const zoomtoit = bounds.isValid() && !map.getBounds().contains(bounds) && (center || window.location.hash.indexOf('map=') == -1);
+        if (zoomtoit) {
           OSM.router.withoutMoveListener(function () {
             map.fitBounds(bounds);
           });


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/232

On page load if the URL is to a specific way/node by ID, the map will now correctly zoom to that feature same as it did before the timeslider.