### PR TITLE
Gda historybutton

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -310,9 +310,10 @@ $(document).ready(function () {
     };
 
     page.load = function() {
+      // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+      // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+      function originalLoadFunction () {
       var params = querystring.parse(location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params);
-
       if (params.query) {
         $("#sidebar .search_form input[name=query]").value(params.query);
       }
@@ -320,6 +321,16 @@ $(document).ready(function () {
         $("#sidebar .search_form input[name=query]").focus();
       }
       return map.getState();
+      }  // end originalLoadFunction
+
+      // "if map.timeslider" only try to add the timeslider if we don't already have it
+      if (map.timeslider) {
+        originalLoadFunction();
+      }
+      else {
+        var params = querystring.parse(location.search.substring(1));
+        addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+      }
     };
 
     return page;
@@ -337,9 +348,20 @@ $(document).ready(function () {
     // page.load was originally simply the addObject() call
     // but with MBGLTimeSlider we need to wait for it to become ready
     page.load = function(path, id) {
-      addOpenHistoricalMapTimeSlider(map, {}, function () {
-        addObject(type, id, true);
-      });
+      // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+      // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+      function originalLoadFunction () {
+      addObject(type, id, true);
+      }  // end originalLoadFunction
+
+      // "if map.timeslider" only try to add the timeslider if we don't already have it
+      if (map.timeslider) {
+        originalLoadFunction();
+      }
+      else {
+        var params = querystring.parse(location.search.substring(1));
+        addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+      }
     };
 
     function addObject(type, id, center) {

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -10,14 +10,24 @@ OSM.Changeset = function (map) {
   };
 
   page.load = function(path, id) {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     if(id)
       currentChangesetId = id;
     initialize();
 
-    var params = querystring.parse(path.substring(path.indexOf('?') + 1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
-      addChangeset(currentChangesetId, true);
-    });
+    addChangeset(currentChangesetId, true);
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   function addChangeset(id, center) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -392,10 +392,20 @@ OSM.Directions = function (map) {
   };
 
   page.load = function() {
-    var params = querystring.parse(location.search.substring(1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     page.pushstate();
-    });
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function() {

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -63,8 +63,9 @@ OSM.Export = function(map) {
   };
 
   page.load = function() {
-    var params = querystring.parse(location.search.substring(1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     map
       .addLayer(locationFilter)
       .on("moveend", update);
@@ -74,9 +75,18 @@ OSM.Export = function(map) {
     $(".export_form").on("submit", checkSubmit);
 
     update();
-    });
 
     return map.getState();
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function() {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -149,8 +149,7 @@ OSM.History = function(map) {
   };
 
   page.load = function() {
-    var params = querystring.parse(location.search.substring(1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    function originalLoadFunction () {
     map.addLayer(group);
 
     if (window.location.pathname === '/history') {
@@ -160,7 +159,17 @@ OSM.History = function(map) {
     map.on("zoomend", updateBounds);
 
     update();
-    });
+    }
+
+    // the original paghe.load content is the function above, and is used when one visits this page, first load OR the History button
+    // but don't try to add the timeslider if it's already there, that's a silent-but-deadly error
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }    
   };
 
   page.unload = function() {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -149,6 +149,7 @@ OSM.History = function(map) {
   };
 
   page.load = function() {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
     function originalLoadFunction () {
     map.addLayer(group);
 
@@ -159,17 +160,16 @@ OSM.History = function(map) {
     map.on("zoomend", updateBounds);
 
     update();
-    }
+    }  // end originalLoadFunction
 
-    // the original paghe.load content is the function above, and is used when one visits this page, first load OR the History button
-    // but don't try to add the timeslider if it's already there, that's a silent-but-deadly error
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
     if (map.timeslider) {
       originalLoadFunction();
     }
     else {
       var params = querystring.parse(location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }    
+    }
   };
 
   page.unload = function() {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -150,6 +150,7 @@ OSM.History = function(map) {
 
   page.load = function() {
     // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
     function originalLoadFunction () {
     map.addLayer(group);
 
@@ -162,7 +163,7 @@ OSM.History = function(map) {
     update();
     }  // end originalLoadFunction
 
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
     if (map.timeslider) {
       originalLoadFunction();
     }

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -100,8 +100,9 @@ OSM.NewNote = function(map) {
   }
 
   page.load = function (path) {
-    var params = querystring.parse(path.substring(path.indexOf('?') + 1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     if (addNoteButton.hasClass("disabled")) return;
     if (addNoteButton.hasClass("active")) return;
 
@@ -111,6 +112,7 @@ OSM.NewNote = function(map) {
 
     var markerLatlng;
 
+    var params = querystring.parse(path.substring(path.indexOf('?') + 1));
     if (params.lat && params.lon) {
       markerLatlng = L.latLng(params.lat, params.lon);
     } else {
@@ -154,9 +156,18 @@ OSM.NewNote = function(map) {
       e.preventDefault();
       createNote(newNote, e.target.form, '/api/0.6/notes.json');
     });
-    });
 
     return map.getState();
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -46,10 +46,20 @@ OSM.Note = function (map) {
   };
 
   page.load = function() {
-    var params = querystring.parse(location.search.substring(1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     initialize(moveToNote);
-    });
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   function initialize(callback) {

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -345,7 +345,9 @@ OSM.Query = function(map) {
     var params = querystring.parse(path.substring(path.indexOf('?') + 1)),
       latlng = L.latLng(params.lat, params.lon);
 
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
     if (!window.location.hash && !noCentre && !map.getBounds().contains(latlng)) {
       OSM.router.withoutMoveListener(function () {
         map.setView(latlng, 15);
@@ -353,7 +355,16 @@ OSM.Query = function(map) {
     }
 
     queryOverpass(params.lat, params.lon);
-    });
+    }  // end originalLoadFunction
+
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function(sameController) {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -128,6 +128,7 @@ OSM.Search = function(map) {
 
   page.load = function() {
     // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
     function originalLoadFunction () {
     $(".search_results_entry").each(function(index) {
       var entry = $(this);
@@ -157,7 +158,7 @@ OSM.Search = function(map) {
     return map.getState();
     }  // end originalLoadFunction
 
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
     if (map.timeslider) {
       originalLoadFunction();
     }

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -127,8 +127,8 @@ OSM.Search = function(map) {
   };
 
   page.load = function() {
-    var params = querystring.parse(location.search.substring(1));
-    addOpenHistoricalMapTimeSlider(map, params, function () {
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    function originalLoadFunction () {
     $(".search_results_entry").each(function(index) {
       var entry = $(this);
       $.ajax({
@@ -153,9 +153,18 @@ OSM.Search = function(map) {
         }
       });
     });
-    });
 
     return map.getState();
+    }  // end originalLoadFunction
+
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.search.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function() {


### PR DESCRIPTION
Rework the `page.load` patches which call `addOpenHistoricalMapTimeSlider()` so they only do it if there isn't a timeslider on the map already. This corrects issues as noted below:

https://github.com/OpenHistoricalMap/issues/issues/267

https://github.com/OpenHistoricalMap/issues/issues/232

https://github.com/OpenHistoricalMap/issues/issues/232#issuecomment-887625675

https://github.com/OpenHistoricalMap/issues/issues/232#issuecomment-887851686
