### PR TITLE
correct formatHash() race condition in MBGL slider

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -216,8 +216,8 @@ OSM = {
       hash += '&layers=' + layers;
     }
 
-    // timeslider state
-    if (args instanceof L.Map && args.timeslider && args.timeslider instanceof L.Control.MBGLTimeSlider) {
+    // timeslider state: make sure we got a map, which has the Leaflet control, which in turn does have the underlying real control ready
+    if (args instanceof L.Map && args.timeslider && args.timeslider instanceof L.Control.MBGLTimeSlider && args.timeslider._timeslider ) {
       hash += '&date=' + args.timeslider.getDate();
       hash += '&daterange=' + args.timeslider.getRange().join(',');
     }


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/286

When `formatHash()` is called there is a check whether the map's timeslider is ready. This is now tighter and checks that the Leaflet slider _and also the underlying MNBGL slider_ are both ready.