### PR TITLE
TimeSlider, improve URL params detection

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -328,7 +328,7 @@ $(document).ready(function () {
         originalLoadFunction();
       }
       else {
-        var params = querystring.parse(location.search.substring(1));
+        var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
         addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
       }
     };
@@ -359,7 +359,7 @@ $(document).ready(function () {
         originalLoadFunction();
       }
       else {
-        var params = querystring.parse(location.search.substring(1));
+        var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
         addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
       }
     };

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -25,7 +25,7 @@ OSM.Changeset = function (map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -403,7 +403,7 @@ OSM.Directions = function (map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -84,7 +84,7 @@ OSM.Export = function(map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -168,7 +168,7 @@ OSM.History = function(map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -165,7 +165,7 @@ OSM.NewNote = function(map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -57,7 +57,7 @@ OSM.Note = function (map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -362,7 +362,7 @@ OSM.Query = function(map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -163,7 +163,7 @@ OSM.Search = function(map) {
       originalLoadFunction();
     }
     else {
-      var params = querystring.parse(location.search.substring(1));
+      var params = querystring.parse(location.hash.substring(1));
       addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
     }
   };


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/299

This patch improves the detection of URL params when loading the TimeSlider. The prior code would read from `location.search` which is `?` params, while in many cases such as the one described the params are in `location.hash` aka `#` params.

After this patch, the URL-supplied state is applied and preserved more reliably.