### PR TITLE
spritesheet URL production/staging

### DIFF
--- a/app/assets/javascripts/ohm.style.js
+++ b/app/assets/javascripts/ohm.style.js
@@ -12,7 +12,13 @@ const ohmTileServicesLists = {
   ],
 };
 
+const spriteSheetUrls = {
+  "production": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet-production",
+  "staging": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet",
+};
+
 const ohmTileServicesList = ohmTileServicesLists[ohmTileServiceName];
+const spriteSheetUrl = spriteSheetUrls[ohmTileServiceName];
 
 const ohmStyle = {
   "version": 8,
@@ -24,7 +30,7 @@ const ohmStyle = {
       "tiles": ohmTileServicesList,
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet",
+  "sprite": spriteSheetUrl,
   "glyphs": "https://go-spatial.github.io/carto-assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
**BEFORE PROCEEDING, REFER TO https://github.com/OpenHistoricalMap/map-styles/pull/18**

**That pull request includes the new files which this PR will begin requesting. If you don't do that other one first, the OHM website will start requesting a spritesheet which does not exist.**

Check first that these files load in your browser:
- https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet-production.json
- https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet-production.png

This is the second part of https://github.com/OpenHistoricalMap/issues/issues/320 and will cause the OHM website to dynamically determine which spritesheet to use, in much the same way as it determines which tile service URL to use.