### PR TITLE
Center profile page content

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1396,7 +1396,7 @@ tr.turn:hover {
 
 .content-inner {
   position: relative;
-  max-width: 900px;
+  max-width: 960px;
   margin: auto;
   padding: $lineheight;
 }
@@ -1597,9 +1597,6 @@ tr.turn:hover {
 
 .users-show {
   // Silly exception; remove when user page is redesigned.
-  .content-inner {
-    max-width: none;
-  }
   p#no_home_location {
     margin: $lineheight;
   }


### PR DESCRIPTION
Please note that this change slightly increases the content width of other pages. It might be better to merge the changes from openstreetmap-website, which will make both sites more consistent.

Before:
![before](https://user-images.githubusercontent.com/19364673/151515045-08c005f0-b0f7-4b52-a589-24c1083f97df.png)

After:
![after](https://user-images.githubusercontent.com/19364673/151515057-d8fd8b3b-98a0-4ba1-86c3-90dfb97f3e47.png)
