### PR TITLE
Vector basemaps minZoom 1 instead of 2

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -26,7 +26,7 @@ L.OSM.Map = L.Map.extend({
       style: ohmVectorStyles.Original,
       accessToken: "no-token",
       localIdeographFontFamily: "'Noto Sans', 'Noto Sans CJK SC', sans-serif",
-      minZoom: 2,  /* match to "L.OSM.Map" options in index.js */
+      minZoom: 1,  /* leave at 1 even if L.OSM.Map has something deeper */
       maxZoom: 20,  /* match to "L.OSM.Map" options in index.js */
     }));
 
@@ -38,7 +38,7 @@ L.OSM.Map = L.Map.extend({
       style: ohmVectorStyles.Woodblock,
       accessToken: "no-token",
       localIdeographFontFamily: "'Noto Sans', 'Noto Sans CJK SC', sans-serif",
-      minZoom: 2,  /* match to "L.OSM.Map" options in index.js */
+      minZoom: 1,  /* leave at 1 even if L.OSM.Map has something deeper */
       maxZoom: 20,  /* match to "L.OSM.Map" options in index.js */
     }));
 


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/353#issuecomment-1089201137

When the OHM map is zoomed outward to z2, the OHM vector basemaps which use MBGL stop updating because they had a `minZoom: 2` and MBGL's zoom calculations are offset by 1 from Leaflet's. This two-line PR changes the MBGL layers to `minZoom: 1` so they will work at z2.