### PR TITLE
add maxBounds to map

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -85,6 +85,7 @@ $(document).ready(function () {
     contextmenu: true,
     minZoom: 2,  /* match to "L.MapboxGL" options in leaflet.map.js */
     maxZoom: 20,  /* match to "L.MapboxGL" options in leaflet.map.js */
+    maxBounds: [[-180, -90], [180, 90]],
   });
 
   map.attributionControl.setPrefix('');


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/353

This simply adds a maxBounds to the map, which Dan points out may prevent scrolling out of the bounds of the vector map, which seems to cause problems.