### PR TITLE
Remove AOL and Wordpress nonworking auth logins

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -44,8 +44,6 @@
         <% if Settings.key?(:wikipedia_auth_id) -%>
         <li><%= auth_button "wikipedia", "wikipedia" %></li>
         <% end -%>
-        <li><%= auth_button "wordpress", "openid", :openid_url => "wordpress.com" %></li>
-        <li><%= auth_button "aol", "openid", :openid_url => "aol.com" %></li>
       </ul>
 
       <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>


### PR DESCRIPTION
for https://github.com/OpenHistoricalMap/issues/issues/389