### PR TITLE
timeslider init, negative and short years

### DIFF
--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -24,10 +24,10 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
     },
     position: 'bottomright',
   };
-  if (params && params.date && typeof params.date == 'string' && params.date.match(/^\d\d\d\d\-\d\d\-\d\d$/)) {
+  if (params && params.date && typeof params.date == 'string' && params.date.match(/^\-?\d{1,4}\-\d\d\-\d\d$/)) {
     sliderOptions.date = params.date;
   }
-  if (params && params.daterange && typeof params.daterange == 'string' && params.daterange.match(/^\d\d\d\d\-\d\d\-\d\d,\d\d\d\d\-\d\d\-\d\d$/)) {
+  if (params && params.daterange && typeof params.daterange == 'string' && params.daterange.match(/^\-?\d{1,4}\-\d\d\-\d\d,\-?\d{1,4}\-\d\d\-\d\d$/)) {
     sliderOptions.range = params.daterange.split(',');
   }
 


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/494

The URL parser on page load will now match negative years and years with less than 4 digits, and pass them on to the timeslider.

http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=-583-06-09&daterange=-900-07-03,-100-05-04
http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=583-06-09&daterange=100-05-04,900-07-03
http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=25-06-09&daterange=10-05-04,50-07-03
http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=-25-06-09&daterange=-50-07-03,-10-05-04
http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=5-06-09&daterange=1-05-04,5-07-03
http://localhost:3000/#map=16/47.6041/-122.3367&layers=O&date=-2-06-09&daterange=-5-07-03,-1-05-04
