### PR TITLE
Remove spaces from the end of messages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1853,25 +1853,25 @@ en:
       community_driven_title: Community Driven
       community_driven_html: |
         OpenHistoricalMap's community is diverse, passionate, and growing every day.
-        Our contributors include enthusiast mappers, academics, digital  historians, historical societies, 
+        Our contributors include enthusiast mappers, academics, digital  historians, historical societies,
         and many more. To learn more about the community, see the <a href='%{diary_path}'>user diaries</a> etc
       open_data_title: Open Data
       open_data_html: |
         <p>OpenHistoricalMap is <i>open data</i>: you are free to use it for any purpose
         under the terms of the data you are using. OpenHistoricalMap identifies license
         and citation requirements at the object level (if any). Credit or citation to
-        OpenHistoricalMap for consolidating this data is appreciated, but not required. 
-        If you alter or build upon the data in certain ways, you may distribute the result only 
-        under the same licence. See the <a href='%{copyright_path}'>Copyright and 
+        OpenHistoricalMap for consolidating this data is appreciated, but not required.
+        If you alter or build upon the data in certain ways, you may distribute the result only
+        under the same licence. See the <a href='%{copyright_path}'>Copyright and
         License page</a> for details.</p>
-        <p>You can access OHM data through various services, beyond just this website. 
-        See a list of available production and staging websites and APIs on 
-        <a href='https://wiki.openstreetmap.org/wiki/Open_Historical_Map#OHM_Web_Services'>our Wiki page</a>.</p> 
+        <p>You can access OHM data through various services, beyond just this website.
+        See a list of available production and staging websites and APIs on
+        <a href='https://wiki.openstreetmap.org/wiki/Open_Historical_Map#OHM_Web_Services'>our Wiki page</a>.</p>
       legal_title: Legal
       legal_1_html: |
         This site and many other related services are formally operated by the
-        very informal OpenHistoricalMap collective 
-        on behalf of the community. 
+        very informal OpenHistoricalMap collective
+        on behalf of the community.
       legal_2_html: |
         Please contact the OHM team at <a href='mailto:historic@opensteetmap.org'>historic@opensteetmap.org</a>
         if you have licensing, copyright or other legal questions.
@@ -1890,23 +1890,23 @@ en:
       legal_babble:
         title_html: Copyright and License
         intro_1_html: |
-          <b>OpenHistoricalMap (OHM)</b> provides historical mapping and related data, 
-          licensed by contributors at the object level. Contributors are strongly 
-          encouraged to contribute data using the 
-          <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0</a> 
-          license, but in the interest of protecting the rights of historical data 
-          creators, such as academics, other open licenses, such as any combination 
-          of CC, BY, SA, and NC are supported, as well. You are responsible for 
-          understanding the terms of the licenses included in the data you copy, 
+          <b>OpenHistoricalMap (OHM)</b> provides historical mapping and related data,
+          licensed by contributors at the object level. Contributors are strongly
+          encouraged to contribute data using the
+          <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0</a>
+          license, but in the interest of protecting the rights of historical data
+          creators, such as academics, other open licenses, such as any combination
+          of CC, BY, SA, and NC are supported, as well. You are responsible for
+          understanding the terms of the licenses included in the data you copy,
           distribute, transmit, and adapt.
         intro_2_html: |
-          You are free to copy, distribute, transmit, and adapt our data, as long as 
-          you abide by the terms of the data you are copying, distributing, or adapting. 
-          If you alter or build upon the data on this site, you may distribute the result 
-          only under the terms of the underlying data objects’ licenses. 
+          You are free to copy, distribute, transmit, and adapt our data, as long as
+          you abide by the terms of the data you are copying, distributing, or adapting.
+          If you alter or build upon the data on this site, you may distribute the result
+          only under the terms of the underlying data objects’ licenses.
         intro_3_1_html: |
-          The cartography in our map tiles is licensed under the terms of the objects 
-          the tiles contain. Our map styles and  documentation are licensed under the 
+          The cartography in our map tiles is licensed under the terms of the objects
+          the tiles contain. Our map styles and  documentation are licensed under the
           Creative Commons Attribution “No Rights Reserved” Public Domain license (CC0).
         credit_title_html: How to credit OpenHistoricalMap
         credit_1_html: |
@@ -1914,7 +1914,7 @@ en:
           required by the underlying data. Citations, however, are appreciated
           as "OpenHistoricalMap contributors"
         credit_2_1_html: |
-          For a browsable electronic map, OHM prefers the optional credits appear 
+          For a browsable electronic map, OHM prefers the optional credits appear
           in the lower-right corner of the map.
           For example:
         attribution_example:
@@ -1927,7 +1927,7 @@ en:
         contributors_title_html: Our contributors
         contributors_intro_html: |
           Our contributors are many, many individuals and organizations. We would
-          not exist without their efforts. 
+          not exist without their efforts.
         contributors_cambridge-anr_html: |
           Contains data created by <a href="https://www.campop.geog.cam.ac.uk/research/projects/internationaloccupations/enchpopgos/france/">The Cambridge Group for the History of Population and Social Structures</a> <a href="https://anrcommunes.hypotheses.org/">ANR Communes</a> project.
         contributors_ned_html: |
@@ -2172,13 +2172,13 @@ en:
           whatever historical features are interesting to you. Please map from any old
           or out-of-copyright maps you can find. We're very import-friendly, as well.
         off_html: |
-          What it <em>doesn't</em> include is opinionated data like ratings, and data 
-          from copyrighted sources. 
+          What it <em>doesn't</em> include is opinionated data like ratings, and data
+          from copyrighted sources.
       basic_terms:
         title: Basic Terms For Mapping
         paragraph_1_html: |
           OpenHistoricalMap uses the same lingo as OpenStreetMap (OSM). In general, if you have any
-          questions, you can answer them with the same solutions as for OSM. 
+          questions, you can answer them with the same solutions as for OSM.
           Here are a few key words that'll come in handy.
         editor_html: |
           An <strong>editor</strong> is a program or website you can use to edit the map.


### PR DESCRIPTION
Spaces at the end of messages are almost impossible to see and edit in translatewiki.