### PR TITLE
Fix plural irregularities in English strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,6 +346,7 @@ en:
       history_title_html: "Way History: %{name}"
       nodes: "Nodes"
       nodes_count:
+        one: "%{count} node"
         other: "%{count} nodes"
       also_part_of_html:
         one: "part of way %{related_ways}"
@@ -528,7 +529,6 @@ en:
       comment_link: Comment on this entry
       reply_link: Send a message to the author
       comment_count:
-        zero: No comments
         one: "%{count} comment"
         other: "%{count} comments"
       edit_link: Edit this entry
@@ -1422,7 +1422,6 @@ en:
     show:
       title: "%{status} Issue #%{issue_id}"
       reports:
-        zero: No reports
         one: 1 report
         other: "%{count} reports"
       report_created_at: "First reported at %{datetime}"


### PR DESCRIPTION
Remove "zero" value from the plural forms of two strings, and add a "one" value for one string. In the current state, these three strings look erroneous to the translatewiki validator.

All these changes were also made in OpenStreetMap.