### PR TITLE
Update Dockerfile to include image manipulation binaries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,6 @@ RUN apt-get update \
       unzip \
       nodejs \
       npm \
-      advancecomp \
-      gifsicle \
-      libjpeg-progs \
-      jhead \
-      jpegoptim \
-      optipng \
-      pngcrush \
-      pngquant \
  && npm install --global yarn \
  # We can't use snap packages for firefox inside a container, so we need to get firefox+geckodriver elsewhere
  && add-apt-repository -y ppa:mozillateam/ppa \
@@ -63,4 +55,3 @@ RUN bundle install
 ADD package.json yarn.lock /app/
 ADD bin/yarn /app/bin/
 RUN bundle exec bin/yarn install
-RUN bundle exec bin/yarn global add svgo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,7 +9,7 @@ RUN apt-get update \
       curl \
       default-jre-headless \
       file \
-      firefox-geckodriver \
+      gpg-agent \
       libarchive-dev \
       libffi-dev \
       libgd-dev \
@@ -19,14 +19,29 @@ RUN apt-get update \
       libxml2-dev \
       libxslt1-dev \
       locales \
-      nodejs \
       postgresql-client \
-      ruby2.7 \
-      ruby2.7-dev \
+      ruby \
+      ruby-dev \
+      ruby-bundler \
+      software-properties-common \
       tzdata \
       unzip \
-      yarnpkg \
-      git \
+      nodejs \
+      npm \
+      advancecomp \
+      gifsicle \
+      libjpeg-progs \
+      jhead \
+      jpegoptim \
+      optipng \
+      pngcrush \
+      pngquant \
+ && npm install --global yarn \
+ # We can't use snap packages for firefox inside a container, so we need to get firefox+geckodriver elsewhere
+ && add-apt-repository -y ppa:mozillateam/ppa \
+ && echo "Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001" > /etc/apt/preferences.d/mozilla-firefox \
+ && apt-get install --no-install-recommends -y \
+      firefox-geckodriver \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -42,14 +57,10 @@ WORKDIR /app
 
 # Install Ruby packages
 ADD Gemfile Gemfile.lock /app/
-RUN gem install bundler \
- && bundle install
+RUN bundle install
 
 # Install NodeJS packages using yarn
 ADD package.json yarn.lock /app/
 ADD bin/yarn /app/bin/
 RUN bundle exec bin/yarn install
-
-# Update vendor assets
-ADD Vendorfile /app/
-RUN vendorer update
+RUN bundle exec bin/yarn global add svgo

--- a/config/image_optim/development.yml
+++ b/config/image_optim/development.yml
@@ -1,0 +1,12 @@
+skip_missing_workers: true
+advpng: false
+gifsicle: false
+jhead: false
+jpegoptim: false
+jpegtran: false
+optipng: false
+oxipng: false
+pngquant: false
+pngout: false
+pngcrush: false
+svgo: false


### PR DESCRIPTION
In starting to sync with the parent project we've found that libraries such as `advpng`, `gifsicle`, `jhead`, `pngcrush`, `svgo` and so on–mentioned in the macOS section of INSTALL.md–were not being installed into the Docker version, causing warnings when running a `docker compose up`.

This pull request adds those libraries to `Dockerfile`.

I'll note that there is still one warning
```
WARN: advpng none at /usr/bin/advpng (== none) is of unknown version
```
which is [said to be a result of bad packaging](https://bugs.launchpad.net/ubuntu/+source/advancecomp/+bug/1797662).