### PR TITLE
Inspector fix double slash URL

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -422,7 +422,7 @@ $(document).ready(function () {
         onFeatureLoaded: function (type, id, xmldoc) {
             console.log([ 'loaded feature', type, id, xmldoc ]);
         },
-        apiBaseUrl: "/api/"
+        apiBaseUrl: "/api",  // no trailing /
     });
     inspector.selectFeatureFromUrl();
   }


### PR DESCRIPTION
See also https://github.com/OpenHistoricalMap/issues/issues/627

The Inspector was being given a `apiBaseUrl` with a `/` at the end, thus https://staging.openhistoricalmap.org/api//0.6/way/198553377

Prior to the recent upstream change, this was just fine. But now the doubled / means that the path gives a 404 Not Found.