### PR TITLE
Enables iframe embeddable OHM maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Search the network panel for BBOX and you’ll find an API call like this: https
 
 Putting that as the wget [URL] -O map.osm target of the following shell script would get you all the features in that BBOX.
 
+Alternatively, you can use the [NGMDB's Extent Helper](https://ngmdb.usgs.gov/extent/) to draw your bounding box and copy its corners from the __CSV OSM (Decimal Degrees - W, S, E, N)__ output field.
+
+Know that, however you do it, the bounding box must be smaller than 0.25 [square degrees (deg²)](https://en.wikipedia.org/wiki/Square_degree), contain less than 100,000 nodes, and possibly other limits.
+
 Run this inside the Docker container:
 
 ```bash
@@ -118,6 +122,32 @@ psql -U $POSTGRES_USER -h $POSTGRES_HOST -d $POSTGRES_DATABASE -c "select setval
 psql -U $POSTGRES_USER -h $POSTGRES_HOST -d $POSTGRES_DATABASE -c "select setval('current_ways_id_seq', (select max(way_id) from ways));"
 psql -U $POSTGRES_USER -h $POSTGRES_HOST -d $POSTGRES_DATABASE -c "select setval('current_relations_id_seq', (select max(relation_id) from relations));"
 ```
+
+OHM does make its planet files available, daily, at http://planet.openhistoricalmap.org/?prefix=planet/; in Sep 2023 the size of these files hovers around 800Mb. The import process is identical to that outlined above with the exception that the `osmosis` call would be changed to something like
+
+```
+osmosis --read-pbf \
+        file=planet-230918_0002.osm.pbf \
+        --write-apidb \
+        host=$POSTGRES_HOST \
+        database=$POSTGRES_DATABASE \
+        user=$POSTGRES_USER \
+        password=$POSTGRES_PASSWORD \
+        validateSchemaVersion=no
+```
+but the default Docker configuration does not allow for that much data.
+
+If you find that you need to reset your database, the command to _truncate all current and history tables in an API database_ is:
+
+```
+osmosis --td \
+        host=$POSTGRES_HOST \
+        database=$POSTGRES_DATABASE \
+        user=$POSTGRES_USER \
+        password=$POSTGRES_PASSWORD \
+        validateSchemaVersion=no
+```
+
 
 ## Updating iD
 

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -334,9 +334,15 @@ L.OSM.share = function (options) {
         params.marker = latLng.lat + "," + latLng.lng;
       }
 
+      const
+        parsedHash = new URLSearchParams(location.hash),
+        embeddedMapPath = parsedHash.get('#map'),
+        embeddedMapDate = parsedHash.get('date')
+      ;
+
       $("#embed_html").val(
-        "<iframe width=\"425\" height=\"350\" src=\"" +
-          escapeHTML(OSM.SERVER_PROTOCOL + "://" + OSM.SERVER_URL + "/export/embed.html?" + $.param(params)) +
+        "<iframe width=\"425\" height=\"350\" frameborder=\"0\" scrolling=\"no\" marginheight=\"0\" marginwidth=\"0\" src=\"" +
+          OSM.EMBED_SERVER_URL + location.hash + '&bbox=' + params.bbox +
           "\" style=\"border: 1px solid black\"></iframe><br/>" +
           "<small><a href=\"" + escapeHTML(map.getUrl(marker)) + "\">" +
           escapeHTML(I18n.t("javascripts.share.view_larger_map")) + "</a></small>");

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -10,6 +10,7 @@ OSM = {
   MAX_REQUEST_AREA:        <%= Settings.max_request_area.to_json %>,
   SERVER_PROTOCOL:         <%= Settings.server_protocol.to_json %>,
   SERVER_URL:              <%= Settings.server_url.to_json %>,
+  EMBED_SERVER_URL:        <%= Settings.embed_server_url.to_json %>,
   API_VERSION:             <%= Settings.api_version.to_json %>,
   STATUS:                  <%= Settings.status.to_json %>,
   MAX_NOTE_REQUEST_AREA:   <%= Settings.max_note_request_area.to_json %>,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # The server protocol and host
 server_protocol: "http"
 server_url: "openhistoricalmap.example.com"
+embed_server_url: "https://embed.openhistoricalmap.org/"
 # Publisher
 #publisher_url: ""
 # The generator
@@ -91,7 +92,7 @@ nominatim_url: "https://nominatim.openhistoricalmap.org/"
 # Default editor
 default_editor: "id"
 # OAuth application for the web site
-#oauth_application: "OAUTH_CLIENT_ID"
+# oauth_application: "OAUTH_CLIENT_ID"
 # oauth_key: "OAUTH_KEY"
 # OAuth consumer key for iD
 #id_application: ""


### PR DESCRIPTION
Finishes https://github.com/OpenHistoricalMap/issues/issues/485 by leveraging updated MapLibre and addressing feedback about incorporating bbox into hash. Note that this works in concert with a PR on ohm-embed-1yr.