### PR TITLE
Polish site description

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1516,8 +1516,7 @@ en:
     edit_with: Edit with %{editor}
     tag_line: The Free Wiki World Map
     intro_header: Welcome to OpenHistoricalMap!
-    intro_text: "OpenHistoricalMap is a project designed to store and display map data throughout the history of the world. This is a work in progress, we'll be playing around with many new features as we time-enable the site. We encourage you to start playing around and editing data, too."
-    intro_1: "OpenHistoricalMap is a project designed to store and display map data throughout the history of the world. This is a work in progress, we'll be playing around with many new features as we time-enable the site. We encourage you to start playing around and editing data, too."
+    intro_text: OpenHistoricalMap is an interactive map of the world throughout history, created by people like you and dedicated to the public domain.
     intro_2_create_account: "Create a user account"
     partners_title: Partners
     hosting_partners_html: |


### PR DESCRIPTION
Avoid jargon when describing the site in the welcome banner. This isn’t the place for a call to action: it also appears in social media link previews, potentially in a context in which a call to action would distract from the person sharing the link. Also removed an unused message.

Fixes OpenHistoricalMap/issues#566.