### PR TITLE
Update Getting Help links

### DIFF
--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -4,7 +4,7 @@
 
 <p class='introduction'><%= t ".introduction" %></p>
 
-<% sites = %w[welcome beginners_guide mailing_lists irc switch2osm wiki] %>
+<% sites = %w[wiki forum discord slack mailing_list] %>
 <% sites.prepend("welcome") if current_user %>
 
 <div class="row row-cols-sm-3 g-4 mb-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2057,39 +2057,27 @@ en:
       welcome:
         url: /welcome
         title: Welcome to OHM
-        description: Start with this quick guide covering OpenHistoricaltMap basics.
-      beginners_guide:
-        url: https://wiki.openstreetmap.org/wiki/Open_Historical_Map/OHM_Basics
-        title: OHM Basics
-        description: Community maintained guide for beginners.
-      help:
-        url: https://help.openstreetmap.org/
-        title: help.openstreetmap.org
-        description: Ask a question or look up answers on OSM's question-and-answer site.
-      mailing_lists:
-        url: https://lists.openstreetmap.org/listinfo/historic
-        title: OHM Mailing List
-        description: Ask a question or discuss interesting matters on the OHM mailing list - sign up at the link above.
-      forums:
-        url: https://forum.openstreetmap.org/
-        title: Forums
-        description: Questions and discussions for those that prefer a bulletin board style interface.
-      irc:
-        url: https://slack.openstreetmap.us/
-        title: Slack
-        description: Interactive OHM chat on the openhistoricalmap channel, courtesy of OSM-US.
-      switch2osm:
+        description: Start with this quick guide covering OpenHistoricalMap basics.
+      discord:
         url: https://discord.gg/openstreetmap
         title: Discord
-        description: Join the OpenHistoricalMap channel for free-flowing chat about OHM, courtesy of some enthusiastic OHM users.
-      welcomemat:
-        url: https://welcome.openstreetmap.org/
-        title: For Organizations
-        description: With an organization making plans for OpenStreetMap? Find what you need to know in the Welcome Mat.
+        description: "Join the OpenStreetMap World Discord server and get help in the #openhistoricalmap channel."
+      forum:
+        url: https://forum.openhistoricalmap.org/
+        title: Forum
+        description: Participate in longer discussions and informal chat rooms using your OHM account.
+      mailing_list:
+        url: https://lists.openstreetmap.org/listinfo/historic
+        title: Mailing List
+        description: Subscribe to our low-volume mailing list.
+      slack:
+        url: https://slack.openstreetmap.us/
+        title: Slack
+        description: "Invite yourself to the OpenStreetMap U.S. Slack workspace and join the #openhistoricalmap channel."
       wiki:
-        url: https://wiki.openstreetmap.org/wiki/Open_Historical_Map
-        title: OHM Wiki
-        description: Browse the wiki for in-depth OHM information as well as very helpful OSM information, courtesy of the OSM Wiki.
+        url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap
+        title: Wiki
+        description: Community-maintained instructions for using OHM and guidelines for contributing to the project.
     any_questions:
       title: Any questions?
       paragraph_1_html: |


### PR DESCRIPTION
List popular OHM communication channels by community size. Removed duplicate link to welcome page. Distinguish between Slack and IRC and between Discord and switch2osm. Removed unused strings.

Fixes OpenHistoricalMap/issues#593. Working towards OpenHistoricalMap/issues#592 and OpenHistoricalMap/issues#505.