### PR TITLE
Fix for #690: E-mails sent by ohm-website say OpenStreetMap at the top 

### DIFF
--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -12,14 +12,14 @@
             <tr>
               <td style="width: 30px; padding-top: 10px; padding-<%= style_right %>: 10px; padding-bottom: 10px; padding-<%= style_left %>: 0px">
                 <a href="<%= @root_url %>" target="_blank">
-                  <%= image_tag attachments["logo.png"].url, :alt => "OpenStreetMap", :title => "OpenStreetMap", :height => "30", :width => "30", :border => "0" %>
+                  <%= image_tag attachments["logo.png"].url, :alt => "OpenHistoricalMap", :title => "OpenHistoricalMap", :height => "30", :width => "30", :border => "0" %>
                 </a>
               </td>
               <%# the "width: 100%" here looks wrong, but I couldn't find a better way of making Outlook give this cell full width %>
               <td style="width: 100%; padding: 0px; text-align: <%= style_left %>">
                 <%# NB we need "text-decoration: none" twice: GMail only honours it on the <a> but Outlook only on the <strong> %>
                 <a href="<%= @root_url %>" target="_blank" style="text-decoration: none; color: #000">
-                  <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: <%= style_left %>; font-family: 'Helvetica Neue', Arial, sans-serif">OpenStreetMap</strong>
+                  <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: <%= style_left %>; font-family: 'Helvetica Neue', Arial, sans-serif">OpenHistoricalMap</strong>
                 </a>
               </td>
             </tr>
@@ -42,7 +42,7 @@
         <td style="text-align: center; font-size: 11px; font-family: 'Helvetica Neue', Arial, sans-serif">
           <%= yield :footer %>
           <p style="margin-bottom: 10px">
-            <a href="<%= @root_url %>" target="_blank" style="color: #222">OpenStreetMap</a>
+            <a href="<%= @root_url %>" target="_blank" style="color: #222">OpenHistoricalMap</a>
           </p>
         </td>
       </tr>


### PR DESCRIPTION
Addresses https://github.com/OpenHistoricalMap/issues/issues/690 by changing "OpenStreetMap" to "OpenHistoricalMap" throughout views/layouts/user_mailer.html.erb.