### PR TITLE
Fix for #732/Audit use of historic@openstreetmap.org throughout ohm-website 

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2127,7 +2127,7 @@ de:
         Nutzungsbedingungen, Richtlinien zur akzeptablen Nutzung und unserer <a href="/privacy-policy">Datenschutzrichtlinie</a>
         .
       legal_2_html: |-
-        Bitte kontaktiere das OHM-Team unter <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org
+        Bitte kontaktiere das OHM-Team unter <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com
         </a>
         , falls du Fragen bezüglich der Lizenzierung, des Urheberrechts oder anderer rechtlicher Themen hast.
         <br>

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -2012,7 +2012,7 @@ en-GB:
           explicit permission from the copyright holders.
         infringement_2_html: |-
           If you believe that copyrighted material has been inappropriately
-          added to the OpenHistoricalMap database or this site, please send email to historic@openstreetmap.org with "TAKEDOWN REQUEST" in the subject line.
+          added to the OpenHistoricalMap database or this site, please <a href="mailto:ohm-admins@googlegroups.com?subject=TAKEDOWN REQUEST">send email to ohm-admins@googlegroups.com with "TAKEDOWN REQUEST" in the subject line</a>.
         trademarks_title_html: <span id="trademarks"></span>Trademarks
         trademarks_1_html: If you have questions about your use of the OpenHistoricalMap
           name, please see our <a href="https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Copyright">Trademark

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1908,7 +1908,7 @@ en:
         This site and many other related services are formally operated by the
         very informal OpenHistoricalMap collective on behalf of the community. Use of all OHM operated services is subject to our Terms of Use, Acceptable Use Policies and our <a href="/privacy-policy">Privacy Policy</a>.
       legal_2_html: |
-        Please contact the OHM team at <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+        Please contact the OHM team at <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         if you have licensing, copyright or other legal questions.
         <br>
       partners_title: Partners

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2078,7 +2078,7 @@ es:
       legal_1_html: |-
         Este sitio y muchos otros servicios relacionados los gestiona formalmente el colectivo
         muy informal OpenHistoricalMap en nombre de la comunidad. El uso de todos los servicios operados por OHM está sujeto a nuestros Términos de Uso, Políticas de uso aceptable y nuestra <a href="/privacy-policy">Política de privacidad</a> .
-      legal_2_html: "Por favor, póngase en contacto con el equipo de OHM en <a href=\"mailto:historic@openstreetmap.org\">historic@openstreetmap.org</a>
+      legal_2_html: "Por favor, póngase en contacto con el equipo de OHM en <a href=\"mailto:ohm-admins@googlegroups.com\">ohm-admins@googlegroups.com</a>
         si tiene alguna pregunta sobre licencias, derechos de autor u otras cuestiones
         legales. \n<br/>"
       partners_title: Socios

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2210,7 +2210,7 @@ fr:
           de ces droits.
         infringement_2_html: Si vous pensez que du matériel protégé par des droits
           d’auteur a été ajouté de manière inappropriée à la base de données d’OpenHistoricalMap
-          ou à ce site, veuillez envoyer un courriel à historic@openstreetmap.org
+          ou à ce site, veuillez envoyer un courriel à ohm-admins@googlegroups.com
           en indiquant « TAKEDOWN REQUEST » dans la ligne d’objet.
         trademarks_title_html: <span id="trademarks"></span>Marques de commerce
         trademarks_1_html: Si vous avez des questions à propos de l’utilisation du

--- a/config/locales/fy.yml
+++ b/config/locales/fy.yml
@@ -2017,7 +2017,7 @@ fy:
           de útdruklike tastimming fan 'e auteursrjochthawwers.
         infringement_2_html: |-
           At jo miene dat der materiaal mei auteursrjochten ûnrjochtlik
-          oan 'e OpenHistoricalMap-databank of dit webstee taheakke is, stjoer dan in e-mail nei historic@openstreetmap.org mei "TAKEDOWN REQUEST" yn 'e ûnderwerprigel.
+          oan 'e OpenHistoricalMap-databank of dit webstee taheakke is, stjoer dan in e-mail nei ohm-admins@googlegroups.com mei "TAKEDOWN REQUEST" yn 'e ûnderwerprigel.
         trademarks_title_html: <span id="trademarks"></span>Hannelsmerken
         trademarks_1_html: At jo fragen hawwe oer jo gebrûk fan 'e namme OpenHistoricalMap,
           besjoch dan ús <a href="https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Copyright">Hannelsmerkebelied</a>.

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -2039,7 +2039,7 @@ gl:
         uso, as políticas de uso aceptábel e a nosa <a href="/privacy-policy">política
         de privacidade</a>.
       legal_2_html: |-
-        Se tes preguntas sobre as licenzas, os dereitos de autoría ou outras cuestións legais, ponte en contacto co equipo do OHM en <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>.
+        Se tes preguntas sobre as licenzas, os dereitos de autoría ou outras cuestións legais, ponte en contacto co equipo do OHM en <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>.
         <br>
       partners_title: Socios
     copyright:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1979,7 +1979,7 @@ he:
         <p>אפשר לגשת לנתונים של OHM דרך מגוון שירותים, מעבר לאתר הזה.
         אפשר לראות את רשימת האתרים המבצעיים והניסיוניים ונקודות גישת ה־API ב<a href='https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Development#Environments'>דף הוויקי שלנו</a>.</p>
       legal_title: משפטי
-      legal_2_html: "נא ליצור קשר עם צוות OHM בכתובת <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+      legal_2_html: "נא ליצור קשר עם צוות OHM בכתובת <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         \nאם יש לך שאלות בנושא רישוי או זכויות יוצרים או שאלות משפטיות אחרות.\n<br>"
       partners_title: שותפים
     copyright:

--- a/config/locales/ia.yml
+++ b/config/locales/ia.yml
@@ -2020,7 +2020,7 @@ ia:
         Le uso de tote le servicios gerite per OHM es subjecte a nostre conditiones
         de uso e a nostre <a href=\"/privacy-policy\">politica de confidentialitate</a>."
       legal_2_html: |-
-        Per favor contacta le equipa de OHM a <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+        Per favor contacta le equipa de OHM a <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         si tu ha questiones sur licentias, derectos de autor o altere questiones juridic.
         <br>
       partners_title: Partners

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2077,7 +2077,7 @@ it:
         d'uso, alle Politiche di utilizzo accettabile e alla nostra <a href="/privacy-policy">Informativa
         sulla privacy</a>.
       legal_2_html: |-
-        Contatta il team OHM <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+        Contatta il team OHM <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         se hai domande su licenza, copyright o altre questioni legali.
         <br>
       partners_title: Partner

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -2027,7 +2027,7 @@ mk:
         Правилата за прифатлива употреба и нашите <a href="/privacy-policy">Правила
         за затштита на личните податоци</a>.
       legal_2_html: |-
-        Обратете се кај екипата OHM на <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+        Обратете се кај екипата OHM на <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         ако имате прашања за лиценцирање, авторски права или други правни работи.
         <br>
       partners_title: Партнери

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2085,7 +2085,7 @@ nl:
         Beleid voor Aanvaardbaar Gebruik en ons <a href="/privacy-policy">Privacybeleid</a>
         van toepassing.
       legal_2_html: |-
-        Neem contact op met het OHM-team via <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a> als u vragen heeft over licenties, auteursrecht of andere juridische kwesties.
+        Neem contact op met het OHM-team via <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a> als u vragen heeft over licenties, auteursrecht of andere juridische kwesties.
         <br>
       partners_title: Partners
     copyright:
@@ -2159,7 +2159,7 @@ nl:
           toe te voegen zonder uitdrukkelijke toestemming van de houders van de auteursrechten.
         infringement_2_html: Als u van mening bent dat auteursrechtelijk beschermd
           materiaal ongepast is toegevoegd aan de database van OpenHistoricalMap of
-          aan deze site, stuur dan een e-mail naar historic@openstreetmap.org met
+          aan deze site, stuur dan een e-mail naar ohm-admins@googlegroups.com met
           "TAKEDOWN REQUEST" in de onderwerpregel.
         trademarks_title_html: <span id="trademarks"></span>Handelsmerken
         trademarks_1_html: Als u vragen heeft over uw gebruik van de naam OpenHistoricalMap,

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1985,7 +1985,7 @@ pt-PT:
         de Utilização</a>, <a href="https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">Políticas
         de Utilização Aceitável</a> e à nossa <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Política
         de Privacidade</a>.
-      legal_2_html: "Por favor, contacte a equipa da OHM em <a href=\"mailto:historic@openstreetmap.org\">historic@openstreetmap.org</a>
+      legal_2_html: "Por favor, contacte a equipa da OHM em <a href=\"mailto:ohm-admins@googlegroups.com\">ohm-admins@googlegroups.com</a>
         se tiver dúvidas sobre licenças, direitos autorais ou outras questões legais.
         \n<br/>"
       partners_title: Parceiros

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -2153,7 +2153,7 @@ sl:
           avtorsko varovanega vira (npr. Google Zemljevidov ali tiskanih zemljevidov) brez
           izrecnega dovoljenja imetnikov avtorskih pravic.
         infringement_2_html: Če menite, da je bilo avtorsko gradivo v podatkovno zbirko
-          OpenHistoricalMap ali to spletišče dodano neupravičeno, nam na naslov historic@openstreetmap.org
+          OpenHistoricalMap ali to spletišče dodano neupravičeno, nam na naslov ohm-admins@googlegroups.com
           pošljite e-pismo z zadevo »TAKEDOWN REQUEST« (zahteva za odstranitev).
         trademarks_title_html: <span id="trademarks"></span>Tržne znamke
         trademarks_1_html: Če imate vprašanja o vaši uporabi imena OpenHistoricalMap,

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1923,7 +1923,7 @@ vi:
         Quy định Sử dụng Hợp lý</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy?uselang=vi">Quy
         định về Quyền Riêng tư</a> của chúng tôi.
       legal_2_html: |-
-        Xin vui lòng liên lạc với nhóm OHM tại <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a> nếu bạn có thắc mắc về giấy phép, bản quyền, hoặc thắc mắc khác về pháp luật.
+        Xin vui lòng liên lạc với nhóm OHM tại <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a> nếu bạn có thắc mắc về giấy phép, bản quyền, hoặc thắc mắc khác về pháp luật.
         <br>
       partners_title: Nhà bảo trợ
     copyright:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1910,7 +1910,7 @@ zh-CN:
       legal_title: 法律
       legal_1_html: 本网站以及很多其他相关服务由代表社区的非正式OpenHistoricalMap集体所运作。所有使用的OHM运作服务均符合我们的使用条款、可接受使用方针，以及<a
         href="/privacy-policy">隐私政策</a>。
-      legal_2_html: "如果您有许可、版权或其他法律问题，请联系OHM团队 ( <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a>
+      legal_2_html: "如果您有许可、版权或其他法律问题，请联系OHM团队 ( <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
         \n)。\n<br>"
       partners_title: 合作伙伴
     copyright:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1947,7 +1947,7 @@ zh-TW:
       legal_1_html: 本站台以及許多相關服務由代表社群的非正式 OpenHistoricalMap 集體所運作。所有使用的 OHM 運作服務皆符合我們的使用條款、可接受使用方針，以及<a
         href="/privacy-policy">隱私政策</a>。
       legal_2_html: |-
-        若您有任何授權、版權，或其他法律諮詢，請透過電郵 <a href='mailto:historic@openstreetmap.org'>historic@openstreetmap.org</a> 聯絡 OHM 團隊。
+        若您有任何授權、版權，或其他法律諮詢，請透過電郵 <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a> 聯絡 OHM 團隊。
         <br>
       partners_title: 合作夥伴
     copyright:


### PR DESCRIPTION
Fixes https://github.com/OpenHistoricalMap/issues/issues/732 by replacing historic@openstreetmap.org with ohm-admins@googlegroups.com in legal_2 and infringement_2 throughout locale files.