### PR TITLE
Add  condition to check index in user_blocks

### DIFF
--- a/db/migrate/20240405083825_add_creator_index_to_user_blocks.rb
+++ b/db/migrate/20240405083825_add_creator_index_to_user_blocks.rb
@@ -2,6 +2,8 @@ class AddCreatorIndexToUserBlocks < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :user_blocks, [:creator_id, :id], :algorithm => :concurrently
+    unless index_exists?(:user_blocks, [:creator_id, :id])
+      add_index :user_blocks, [:creator_id, :id], algorithm: :concurrently
+    end
   end
 end


### PR DESCRIPTION
Customize the migration script to evaluate if the index exists in the user_blocks table.

cc. @erictheise @danrademacher 