### PR TITLE
Update partner acknowledgments

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -44,7 +44,11 @@
       <div class="welcome p-3" hidden>
         <%= render "sidebar_header", :title => t("layouts.intro_header") %>
         <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
-        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html" %>
+        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
+                                       :devseed => link_to(t("layouts.partners_devseed"), "https://developmentseed.org/"),
+                                       :greeninfo => link_to(t("layouts.partners_greeninfo"), "https://greeninfo.org/"),
+                                       :osmf => link_to(t("layouts.partners_osmf"), "https://osmfoundation.org/"),
+                                       :osmus => link_to(t("layouts.partners_osmus"), "https://openstreetmap.us/") %>
         </p>
         <div class="d-flex gap-2">
           <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -110,9 +110,10 @@
           </svg>
           <h2 class="flex-grow-1 mb-0"><%= t ".partners_title" %></h2>
         </div>
-        <p><%= t "layouts.hosting_partners_2024_html", :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
-                                                       :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
-                                                       :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+        <p><%= t "layouts.hosting_partners_2024_html", :devseed => link_to(t("layouts.partners_devseed"), "https://developmentseed.org/"),
+                                                       :greeninfo => link_to(t("layouts.partners_greeninfo"), "https://greeninfo.org/"),
+                                                       :osmf => link_to(t("layouts.partners_osmf"), "https://osmfoundation.org/"),
+                                                       :osmus => link_to(t("layouts.partners_osmus"), "https://openstreetmap.us/") %>
         </p>
       </section>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1578,16 +1578,13 @@ en:
     tag_line: The Free Wiki World Map
     intro_header: Welcome to OpenHistoricalMap!
     intro_text: OpenHistoricalMap is an interactive map of the world throughout history, created by people like you and dedicated to the public domain.
-    hosting_partners_2024_html: |
-      <p>
-      <a href='https://greeninfo.org'>GreenInfo Network</a> is a nonprofit social-good mapping and communications organization that helps nonprofits and government agencies achieve social, environmental, and other goals using a range of tools, including human-centered design practices, collaborative development, and open source web and geospatial tools.
-      </p>
-      <p>
-      <a href='https://developmentseed.org/'>Development Seed</a> is an engineering and product company that is accelerating the application of earth data to our biggest global challenges. Development Seed leverages massive earth data, cloud computing, geospatial AI, and thoughtful product development.
-      </p>
-    partners_fastly: "Fastly"
-    partners_corpmembers: "OSMF corporate members"
-    partners_partners: "partners"
+    intro_2_create_account: "Create a user account"
+    partners_title: Partners
+    hosting_partners_2024_html: "OpenHistoricalMap is a charter project of %{osmus}, a 501(c)(3) nonprofit organization affiliated with the %{osmf}. Technical development is supported by %{greeninfo} and %{devseed}."
+    partners_devseed: Development Seed
+    partners_greeninfo: GreenInfo Network
+    partners_osmf: OpenStreetMap Foundation
+    partners_osmus: OpenStreetMap U.S.
     tou: "Terms of Use"
     osm_offline: "The OpenHistoricalMap database is currently offline while essential database maintenance work is carried out."
     osm_read_only: "The OpenHistoricalMap database is currently in read-only mode while essential database maintenance work is carried out."


### PR DESCRIPTION
openstreetmap/openstreetmap-website#4572 renamed `hosting_partners_html` with `hosting_partners_2024_html`, but 09ed99a6bed3ebc5c17656b72f545e8122400781 for #261 reverted this change in en.yml without touching the files that use this string. As a result, a cryptic message appeared on the homepage to logged-out users, as well as on the About page. I’ve unreverted the change and updated the acknowledgment. Now it explains our affiliation with OSMUS, which is [a frequently asked question](https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/FAQ#What_is_OHM's_relationship_to_OSM?). GreenInfo Network and Development Seed are mentioned only briefly, to avoid dominating the doorhanger panel. I’ve also refactored the links so that translators aren’t responsible for the link URLs.

Before | After
----|----
<img src="https://github.com/user-attachments/assets/cf242170-e1e1-48e9-be92-a374fc07c861" width="350" alt="Hosting Partners 2024 Html"> | <img src="https://github.com/user-attachments/assets/25f0c637-c717-4f91-a2bd-f25f9b7e0d42" width="350" alt="OpenHistoricalMap is a charter project of OpenStreetMap U.S., a 501(c)(3) nonprofit organization affiliated with the OpenStreetMap Foundation. Technical development is supported by GreenInfo Network and Development Seed.">
