### PR TITLE
add two current branches to "ohm-tests" workflow

### DIFF
--- a/.github/workflows/ohm-tests.yml
+++ b/.github/workflows/ohm-tests.yml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 20241119-upstream
+      - 878-support-multilingual-labels
+      - 961-osm-references-have-reappeared
 #  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Replacing '20241119-upstream' as a branch to test on push with two current dev branches.
