### PR TITLE
Add start and end dates to element labels

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -1,5 +1,6 @@
 class GeocoderController < ApplicationController
   require "cgi"
+  require "date_range"
   require "uri"
   require "rexml/document"
 
@@ -118,7 +119,7 @@ class GeocoderController < ApplicationController
         end
       end
       if start_date || end_date
-        suffix = t ".suffix_format", :dates => printable_date_range(start_date, end_date)
+        suffix = t ".suffix_format", :dates => DateRange.new(start_date, end_date).to_s
       end
 
       @results.push(:lat => lat, :lon => lon,
@@ -133,25 +134,6 @@ class GeocoderController < ApplicationController
     host = URI(Settings.nominatim_url).host
     @error = "Error contacting #{host}: #{e}"
     render :action => "error"
-  end
-
-  def printable_date_range(start_date, end_date)
-    printable_start_date = printable_date(start_date)
-    printable_end_date = printable_date(end_date)
-    if printable_start_date == printable_end_date
-      dates = printable_start_date
-    else
-      dates = t "time.formats.range", :start => printable_start_date, :end => printable_end_date
-    end
-  end
-
-  def printable_date(basic)
-    if basic
-      date = Date.new(basic.to_i)
-      l(date, :format => :brief)
-    else
-      ""
-    end
   end
 
   def search_osm_nominatim_reverse

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -148,7 +148,7 @@ class GeocoderController < ApplicationController
   def printable_date(basic)
     if basic
       date = Date.new(basic.to_i)
-      l(date, :format => "%Y")
+      l(date, :format => :brief)
     else
       ""
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,25 @@ module ApplicationHelper
     tag.time(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
   end
 
+  def printable_date_range(start_date, end_date)
+    printable_start_date = printable_date(start_date)
+    printable_end_date = printable_date(end_date)
+    if printable_start_date == printable_end_date
+      dates = printable_start_date
+    else
+      dates = t "time.formats.range", :start => printable_start_date, :end => printable_end_date
+    end
+  end
+
+  def printable_date(basic)
+    if basic
+      date = Date.new(basic.to_i)
+      l(date, :format => "%Y")
+    else
+      ""
+    end
+  end
+
   def body_class
     if content_for? :body_class
       content_for :body_class

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,7 @@ module ApplicationHelper
   def printable_date(basic)
     if basic
       date = Date.new(basic.to_i)
-      l(date, :format => "%Y")
+      l(date, :format => :brief)
     else
       ""
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,25 +33,6 @@ module ApplicationHelper
     tag.time(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
   end
 
-  def printable_date_range(start_date, end_date)
-    printable_start_date = printable_date(start_date)
-    printable_end_date = printable_date(end_date)
-    if printable_start_date == printable_end_date
-      dates = printable_start_date
-    else
-      dates = t "time.formats.range", :start => printable_start_date, :end => printable_end_date
-    end
-  end
-
-  def printable_date(basic)
-    if basic
-      date = Date.new(basic.to_i)
-      l(date, :format => :brief)
-    else
-      ""
-    end
-  end
-
   def body_class
     if content_for? :body_class
       content_for :body_class

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,4 +1,6 @@
 module BrowseHelper
+  require "date_range"
+
   def element_single_current_link(type, object)
     link_to object, { :class => element_class(type, object), :title => element_title(object), :rel => (link_follow(object) if type == "node") } do
       element_strikethrough object do
@@ -39,7 +41,7 @@ module BrowseHelper
       if (object.tags.include? "start_date") || (object.tags.include? "end_date")
         start_date = (object.tags.include? "start_date") ? object.tags["start_date"].to_s : nil
         end_date = (object.tags.include? "end_date") ? object.tags["end_date"].to_s : nil
-        label = t "printable_name.with_date_html", :name => label, :dates => tag.bdi(printable_date_range(start_date, end_date))
+        label = t "printable_name.with_date_html", :name => label, :dates => tag.bdi(DateRange.new(start_date, end_date).to_s)
       end
 
       if label

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -29,11 +29,21 @@ module BrowseHelper
       locale = available_locales.preferred(preferred_languages, :default => nil)
 
       if object.tags.include? "name:#{locale}"
-        name = t "printable_name.with_name_html", :name => tag.bdi(object.tags["name:#{locale}"].to_s), :id => tag.bdi(name)
+        label = object.tags["name:#{locale}"].to_s
       elsif object.tags.include? "name"
-        name = t "printable_name.with_name_html", :name => tag.bdi(object.tags["name"].to_s), :id => tag.bdi(name)
+        label = object.tags["name"].to_s
       elsif object.tags.include? "ref"
-        name = t "printable_name.with_name_html", :name => tag.bdi(object.tags["ref"].to_s), :id => tag.bdi(name)
+        label = object.tags["ref"].to_s
+      end
+
+      if (object.tags.include? "start_date") || (object.tags.include? "end_date")
+        start_date = (object.tags.include? "start_date") ? object.tags["start_date"].to_s : nil
+        end_date = (object.tags.include? "end_date") ? object.tags["end_date"].to_s : nil
+        label = t "printable_name.with_date_html", :name => label, :dates => tag.bdi(printable_date_range(start_date, end_date))
+      end
+
+      if label
+        name = t "printable_name.with_name_html", :name => tag.bdi(label), :id => tag.bdi(id.to_s)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   html:
     dir: ltr
+  date:
+    formats:
+      brief: "%Y"
   time:
     formats:
       friendly: "%B %e, %Y at %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
     formats:
       friendly: "%B %e, %Y at %H:%M"
       blog: "%B %e, %Y"
+      range: "%{start}\u2009–\u2009%{end}"
   count:
     at_least_pattern: "%{count}+"
   helpers:
@@ -205,6 +206,7 @@ en:
   printable_name:
     version: "v%{version}"
     with_name_html: "%{name} (%{id})"
+    with_date_html: "%{name} [%{dates}]"
     current_and_old_links_html: "%{current_link}, %{old_link}"
   editor:
     default: "Default (currently %{name})"
@@ -680,6 +682,7 @@ en:
         osm_nominatim_reverse_url: https://nominatim.openhistoricalmap.org/
     search_osm_nominatim:
       prefix_format: "%{name}"
+      suffix_format: "[%{dates}]"
       prefix:
         aerialway:
           cable_car: "Cable Car"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,12 +3,14 @@ en:
     dir: ltr
   date:
     formats:
-      brief: "%Y"
+      brief: "%{year}"
+      brief_bce: "%{year} BCE"
+      brief_ce: "%{year} CE"
+      range: "%{start}\u2009–\u2009%{end}"
   time:
     formats:
       friendly: "%B %e, %Y at %H:%M"
       blog: "%B %e, %Y"
-      range: "%{start}\u2009–\u2009%{end}"
   count:
     at_least_pattern: "%{count}+"
   helpers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3416,6 +3416,7 @@ en:
       nothing_found: No features found
       error: "Error contacting %{server}: %{error}"
       timeout: "Timeout contacting %{server}"
+      suffix_format: "[%{dates}]"
     context:
       directions_from: Directions from here
       directions_to: Directions to here

--- a/lib/date_range.rb
+++ b/lib/date_range.rb
@@ -1,0 +1,36 @@
+class DateRange
+  attr_reader :start_date, :end_date
+
+  def initialize(start_date, end_date)
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def to_s
+    parsed_start_date = start_date && Date.new(start_date.to_i)
+    parsed_end_date = end_date && Date.new(end_date.to_i)
+    printable_start_date = printable_date(parsed_start_date, parsed_start_date && parsed_start_date.year < 1)
+    printable_end_date = printable_date(parsed_end_date, (parsed_start_date && parsed_start_date.year < 1) || (parsed_end_date && parsed_end_date.year < 1))
+
+    if printable_start_date == printable_end_date
+      dates = printable_start_date
+    else
+      dates = I18n.t "date.formats.range", :start => printable_start_date, :end => printable_end_date
+    end
+  end
+
+  def printable_date(parsed_date, era)
+    if parsed_date
+      format = "date.formats.brief"
+      if era
+        format = parsed_date.year > 0 ? "date.formats.brief_ce" : "date.formats.brief_bce"
+      end
+      if parsed_date.year < 1
+        parsed_date = Date.new(1 - parsed_date.year)
+      end
+      I18n.t format, :year => "%d" % parsed_date.year
+    else
+      ""
+    end
+  end
+end


### PR DESCRIPTION
Added start and end dates to element labels.

[Element inspector](http://localhost:3000/relation/2749291):

![Relation: Loveland City Landfill [1970 – 1996] (2749291)](https://github.com/user-attachments/assets/4e8962c5-db7a-45b8-9b53-5b2a626834dd)

[Nominatim search results](http://localhost:3000/search?query=Loveland#map=13/39.26761/-84.25810):

![Village Loveland, 45140, United States [1850 – 1876]](https://github.com/user-attachments/assets/f4e2f8c1-c568-4174-8f6e-7b2088b8d05e)

[Overpass API query results](http://localhost:3000/query?lat=39.27274&lon=-84.26145#map=17/39.268336/-84.258184):

![Music School Loveland Music Academy [2007 – 2009]](https://github.com/user-attachments/assets/e64b7fd2-f67d-4269-b244-223994d12ffe)

To do:

* [x] Add date range to element inspector
* [x] Add date range to Nominatim search results
* [x] Add date range to Overpass API query results
* [x] Consolidate date formatting
* [x] Format BCE dates

Fixes OpenHistoricalMap/issues#431 and possibly OpenHistoricalMap/issues#301.