### PR TITLE
Skip to showing overlays if time slider disabled

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -365,7 +365,7 @@ $(document).ready(function () {
         }
 
         var drawing = map._objectLayer.getLayers()[0];
-        if (drawing && ! hasurlparam_daterange) {
+        if (drawing && map.timeslider && ! hasurlparam_daterange) {
           var startdate = drawing.feature.tags.start_date && ! isNaN(parseInt(drawing.feature.tags.start_date)) ? drawing.feature.tags.start_date : undefined;
           var enddate = drawing.feature.tags.end_date && ! isNaN(parseInt(drawing.feature.tags.end_date)) ? drawing.feature.tags.end_date : undefined;
 

--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -34,6 +34,8 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
   // add the slider IF the OSM vector map is the layer showing
   if (getHistoryLayerIfShowing()) {
     addTimeSliderToMap(sliderOptions);
+  } else {
+    onreadycallback();
   }
 
   map.on('baselayerchange', function () {


### PR DESCRIPTION
If we aren’t showing the time slider for some reason, continue on with the upstream codebase’s overlay code.

![An overlay of the Loveland City Landfill atop the Standard layer without the time slider.](https://github.com/user-attachments/assets/75b87fbe-a623-45d7-b639-db7b4507ac82)

Fixes OpenHistoricalMap/issues#915.