### PR TITLE
Rewrite About page

### DIFF
--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -3,13 +3,7 @@
   <%= tag.div :lang => @locale, :dir => t("html.dir") do %>
     <div class="container-lg attr">
       <div class='row'>
-        <div class='col-sm-7 user-image'></div>
-        <div class='col-sm-5 px-5 py-3 byosm'>
-          <p class='h5 text-white text-nowrap'>
-            <%= t ".heading_html", :copyright => tag.span(t(".copyright_symbol_html")),
-                                   :br => tag.br %>
-          </p>
-        </div>
+        <div class='user-image'></div>
       </div>
       <div class='row'>
         <div class="px-5 py-4 bg-black bg-opacity-75">
@@ -27,9 +21,9 @@
             <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
             <path d="m 15,22 c 0,0 5,-4.5199 5,-8 0,-3 -2,-5 -5,-5 -3,0 -5,2 -5,5 0,3.4801 5,8 5,8 z" fill="#c0c0c0" />
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t ".local_knowledge_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".scope_title" %></h2>
         </div>
-        <p><%= t ".local_knowledge_html" %></p>
+        <p><%= t ".scope_html" %></p>
       </section>
 
       <section>
@@ -38,17 +32,25 @@
             <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
             <path d="m 15,7 -6,6 0,7 4,0 0,-4 4,0 0,4 4,0 0,-7 z" fill="#c0c0c0" />
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t ".community_driven_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".contribute_title" %></h2>
         </div>
         <p>
-          <%= t ".community_driven_1_html", :osm_blog_link => link_to(t(".community_driven_osm_blog"),
-                                                                      t(".community_driven_osm_blog_url")),
-                                            :user_diaries_link => link_to(t(".community_driven_user_diaries"),
-                                                                          diary_entries_path),
-                                            :community_blogs_link => link_to(t(".community_driven_community_blogs"),
-                                                                             t(".community_driven_community_blogs_url")),
-                                            :osm_foundation_link => link_to(t(".community_driven_osm_foundation"),
-                                                                            t(".community_driven_osm_foundation_url")) %>
+          <%= t ".contribute_1_html", :wiki_link => link_to(t(".contribute_1_wiki"),
+                                                            t(".contribute_1_wiki_url")),
+                                      :forum_link => link_to(t(".contribute_1_forum"),
+                                                             "https://forum.openhistoricalmap.org/"),
+                                      :user_diaries_link => link_to(t(".contribute_1_user_diaries"),
+                                                                    diary_entries_path),
+                                      :mastodon_link => link_to(t(".contribute_1_mastodon"),
+                                                                "https://mapstodon.space/@ohm") %>
+        </p>
+        <p>
+          <%= t ".contribute_2_html", :create_account_link => link_to(t(".contribute_2_create_account"),
+                                                                      user_new_path),
+                                      :donations_link => link_to(t(".contribute_2_donations"),
+                                                                 "https://openstreetmap.app.neoncrm.com/forms/ohm"),
+                                      :osmus_link => link_to(t(".contribute_2_osmus"),
+                                                             "https://openstreetmap.us/") %>
         </p>
       </section>
 
@@ -61,9 +63,13 @@
           <h2 class="flex-grow-1 mb-0"><%= t ".open_data_title" %></h2>
         </div>
         <p>
-          <%= t ".open_data_1_html", :open_data => tag.i(t(".open_data_open_data")),
-                                     :copyright_license_link => link_to(t(".open_data_copyright_license"),
-                                                                        copyright_path) %></p>
+          <%= t ".open_data_1_html", :reuse_link => link_to(t(".open_data_1_reuse"),
+                                                            t(".open_data_1_reuse_url")) %>
+        </p>
+        <p>
+          <%= t ".open_data_2_html", :copyright_license_link => link_to(t(".open_data_2_copyright_license"),
+                                                                        copyright_path) %>
+        </p>
       </section>
 
       <section id="legal">
@@ -80,22 +86,22 @@
           <h2 class="flex-grow-1 mb-0"><%= t ".legal_title" %></h2>
         </div>
         <p>
-          <%= t ".legal_1_1_html", :openstreetmap_foundation_link => link_to(t(".legal_1_1_openstreetmap_foundation"),
-                                                                             t(".legal_1_1_openstreetmap_foundation_url")),
-                                   :terms_of_use_link => link_to(t(".legal_1_1_terms_of_use"),
-                                                                 t(".legal_1_1_terms_of_use_url")),
-                                   :aup_link => link_to(t(".legal_1_1_aup"),
-                                                        t(".legal_1_1_aup_url")),
-                                   :privacy_policy_link => link_to(t(".legal_1_1_privacy_policy"),
-                                                                   t(".legal_1_1_privacy_policy_url")) %>
+          <%= t ".legal_1_html", :group_link => link_to(t(".legal_1_group"),
+                                                        t(".legal_1_group_url")),
+                                 :terms_of_use_link => link_to(t(".legal_1_terms_of_use"),
+                                                               t(".legal_1_terms_of_use_url")),
+                                 :aup_link => link_to(t(".legal_1_aup"),
+                                                      t(".legal_1_aup_url")),
+                                 :privacy_policy_link => link_to(t(".legal_1_privacy_policy"),
+                                                                 t(".legal_1_privacy_policy_url")) %>
         </p>
         <p>
-          <%= t ".legal_2_1_html", :contact_the_osmf_link => link_to(t(".legal_2_1_contact_the_osmf"),
-                                                                     t(".legal_2_1_contact_the_osmf_url")) %>
+          <%= t ".legal_2_html", :contact_team_link => link_to(t(".legal_2_contact_team"),
+                                                               "mailto:ohm-admins@googlegroups.com") %>
         </p>
         <p>
-          <%= t ".legal_2_2_html", :registered_trademarks_link => link_to(t(".legal_2_2_registered_trademarks"),
-                                                                          t(".legal_2_2_registered_trademarks_url")) %>
+          <%= t ".legal_3_html", :osmf_trademarks_link => link_to(t(".legal_3_osmf_trademarks"),
+                                                                  t(".legal_3_osmf_trademarks_url")) %>
         </p>
       </section>
 

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -63,8 +63,8 @@
           <h2 class="flex-grow-1 mb-0"><%= t ".open_data_title" %></h2>
         </div>
         <p>
-          <%= t ".open_data_1_html", :reuse_link => link_to(t(".open_data_1_reuse"),
-                                                            t(".open_data_1_reuse_url")) %>
+          <%= t ".open_data_1_1_html", :reuse_link => link_to(t(".open_data_1_1_reuse"),
+                                                              t(".open_data_1_1_reuse_url")) %>
         </p>
         <p>
           <%= t ".open_data_2_html", :copyright_license_link => link_to(t(".open_data_2_copyright_license"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1917,66 +1917,64 @@ en:
         newer: Newer Users
   site:
     about:
-      heading_html: "%{copyright}OpenHistoricalMap %{br} contributors"
-      copyright_symbol_html: "&copy;"
-      used_by_html: "%{name} collaboratively stores and displays map data throughout the history of the world."
+      used_by_html: "Explore the world in any time period with %{name}."
       lede_text: |
-        OpenHistoricalMap is built by a community of mappers and historians that contribute and maintain data
-        about the history of the world.
-      local_knowledge_title: Local Knowledge
-      local_knowledge_html: |
-        OpenHistoricalMap is about historical data. Things that used to be there.
-        From a variety of sources, contributed by mappers and historians across the world.
-      community_driven_title: Community Driven
-      community_driven_1_html: |
-        OpenHistoricalMap's community is diverse, passionate, and growing every day.
-        Our contributors include enthusiast mappers, academics, digital  historians, historical societies,
-        and many more.
-        To learn more about the community, see the %{osm_blog_link},
-        %{user_diaries_link}, %{community_blogs_link}, and the
-        %{osm_foundation_link}.
-      community_driven_osm_blog: OHM News
-      community_driven_osm_blog_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/News
-      community_driven_user_diaries: user diaries
-      community_driven_community_blogs: Forum
-      community_driven_community_blogs_url: https://forum.openhistoricalmap.org/
-      community_driven_osm_foundation: '#openhistoricalmap channel on the OSMUS Slack workspace'
-      community_driven_osm_foundation_url: https://slack.openstreetmap.us/
+        OpenHistoricalMap is an ambitious, community-led project to map changes to natural and human geography throughout the world… throughout the ages.
+      scope_title: Big and Small, Then and Now
+      scope_html: |
+        Empires rise and fall. Glaciers disappear. Languages and religions spread from one region to another.
+        Simple dirt paths become busy highways and railways. Modest buildings give way to soaring skyscrapers.
+        And you remember what your neighborhood used to look like.
+        All of it belongs on OpenHistoricalMap.  
+      contribute_title: You Can Help
+      contribute_1_html: |
+        Our growing community of volunteer contributors includes amateur and professional historians, OpenStreetMap and Wikipedia contributors, GIS specialists, and ordinary people knowledgeable about their surroundings.
+        We are passionate about documenting the world and helping real-world communities tell their stories.
+        To learn more about the community, consult %{wiki_link}, visit %{forum_link}, read the %{user_diaries_link}, and follow %{mastodon_link}.
+      contribute_1_wiki: our extensive wiki documentation
+      contribute_1_wiki_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap
+      contribute_1_forum: our discussion forum
+      contribute_1_user_diaries: user diaries
+      contribute_1_mastodon: our Mastodon account
+      contribute_2_html: |
+        You can start contributing to the map today by %{create_account_link}.
+        We also %{donations_link} through %{osmus_link}, a 501(c)(3) nonprofit organization with tax-exempt status.
+        Your generous donation will go directly toward keeping OpenHistoricalMap running smoothly for everyone.
+      contribute_2_create_account: creating a free account
+      contribute_2_donations: accept charitable donations
+      contribute_2_osmus: OpenStreetMap U.S.
       open_data_title: Open Data
       open_data_1_html: |
-        <p>OpenHistoricalMap is <i>open data</i>: you are free to use it for any purpose
-        under the terms of the data you are using. OpenHistoricalMap identifies license
-        and citation requirements at the object level (if any). Credit or citation to
-        OpenHistoricalMap for consolidating this data is appreciated, but not required.
-        If you alter or build upon the data in certain ways, you may distribute the result only
-        under the same licence. See the %{copyright_license_link} for details.</p>
-        <p>You can access OHM data through various services, beyond just this website.
-        See a list of available production and staging websites and APIs on
-        <a href='https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Development#Environments'>our Wiki page</a>.</p>
-      open_data_open_data: open data
-      open_data_copyright_license: Copyright and License page
+        The map on our homepage is just one of many ways to experience the historical information we’ve collected.
+        The underlying data is %{reuse_link} as a download or through various free APIs compatible with open source software.
+      open_data_1_reuse: available for reuse
+      open_data_1_reuse_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Reuse
+      open_data_2_html: |
+        The data is in the public domain unless noted otherwise.
+        You are free to use it for any purpose, without any restrictions.
+        Nonetheless, we greatly appreciate any credit or citation you provide to OpenHistoricalMap.
+        For more details and acknowledgments, see %{copyright_license_link}.
+      open_data_2_copyright_license: Copyright and License
       legal_title: Legal
-      legal_1_1_html: |
-        This site and many other related services are formally operated by the
-        very informal OpenHistoricalMap collective on behalf of the community. Use of all OHM operated services is subject to our Terms of Use, Acceptable Use Policies and our <a href="/privacy-policy">Privacy Policy</a>.
-      legal_1_1_openstreetmap_foundation: OpenStreetMap Foundation
-      legal_1_1_openstreetmap_foundation_url: https://osmfoundation.org/
-      legal_1_1_terms_of_use: Terms of Use
-      legal_1_1_terms_of_use_url: https://osmfoundation.org/wiki/Terms_of_Use
-      legal_1_1_aup: Acceptable Use Policies
-      legal_1_1_aup_url: https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy
-      legal_1_1_privacy_policy: Privacy Policy
-      legal_1_1_privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy
-      legal_2_1_html: |
-        Please contact the OHM team at <a href='mailto:ohm-admins@googlegroups.com'>ohm-admins@googlegroups.com</a>
-        if you have licensing, copyright or other legal questions.
-        <br>
-      legal_2_1_contact_the_osmf: contact the OSMF
-      legal_2_1_contact_the_osmf_url: https://osmfoundation.org/Contact
-      legal_2_2_html: |
-        OpenStreetMap and the magnifying glass logo are %{registered_trademarks_link}.
-      legal_2_2_registered_trademarks: registered trademarks of the OSMF
-      legal_2_2_registered_trademarks_url: https://osmfoundation.org/wiki/Trademark_Policy
+      legal_1_html: |
+        This site and related services are operated by %{group_link} affiliated with OpenStreetMap U.S. on behalf of the community.
+        Use of all OpenHistoricalMap services is subject to our %{terms_of_use_link}, %{aup_link}, and %{privacy_policy_link}.
+      legal_1_group: an informal group
+      legal_1_group_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Governance
+      legal_1_terms_of_use: Terms of Use
+      legal_1_terms_of_use_url: https://osmfoundation.org/wiki/Terms_of_Use
+      legal_1_aup: Acceptable Use Policies
+      legal_1_aup_url: https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy
+      legal_1_privacy_policy: Privacy Policy
+      legal_1_privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy
+      legal_2_html: |
+        Please %{contact_team_link} with any licensing, copyright, or other legal questions.
+      legal_2_contact_team: contact the OpenHistoricalMap team
+      legal_3_html: |
+        OpenHistoricalMap® is a registered trademark (U.S. Reg. No. 90,019,364).
+        OpenStreetMap and the magnifying glass logo are %{osmf_trademarks_link}.
+      legal_3_osmf_trademarks: registered trademarks of the OpenStreetMap Foundation
+      legal_3_osmf_trademarks_url: https://osmfoundation.org/wiki/Trademark_Policy
       partners_title: Partners
     copyright:
       title: Copyright and License

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1944,11 +1944,11 @@ en:
       contribute_2_donations: accept charitable donations
       contribute_2_osmus: OpenStreetMap U.S.
       open_data_title: Open Data
-      open_data_1_html: |
+      open_data_1_1_html: |
         The map on our homepage is just one of many ways to experience the historical information we’ve collected.
         The underlying data is %{reuse_link} as a download or through various free APIs compatible with open source software.
-      open_data_1_reuse: available for reuse
-      open_data_1_reuse_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Reuse
+      open_data_1_1_reuse: available for reuse
+      open_data_1_1_reuse_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Reuse
       open_data_2_html: |
         The data is in the public domain unless noted otherwise.
         You are free to use it for any purpose, without any restrictions.


### PR DESCRIPTION
Rewrote the [About](https://www.openhistoricalmap.org/about) page to more clearly articulate the project’s purpose and legal status, replace irrelevant links with more relevant ones, and make proper use of templating placeholders instead of inline HTML. The incorrect, poorly positioned copyright notice has been removed from the right side of the hero image. Most messages have been renamed to ensure fresh translations and prevent any placeholder mismatch that would trigger a Rails error.

<table>
<thead>
<tr>
<th>Before</th><th>After</th>
</tr>
</thead>
<tbody>
<tr align="center" valign="top">
<td>

![Before](https://github.com/user-attachments/assets/65b6e002-8b6f-43c7-8af2-c4ecf6a10e1b)

</td>
<td>

![After](https://github.com/user-attachments/assets/b0b2db9e-a9eb-4bfd-ac05-eb0732560413)

</td>
</tr>
</tbody>
</table>

Fixes OpenHistoricalMap/issues#505 and fixes OpenHistoricalMap/issues#833.