### PR TITLE
Correct changeset feed license; link to Bluesky

### DIFF
--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -10,9 +10,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
   feed.logo image_url("mag_map-rss2.0.png")
 
   feed.rights :type => "xhtml" do |xhtml|
-    xhtml.a :href => "https://creativecommons.org/licenses/by-sa/2.0/" do |a|
-      a.img :src => image_url("cc_button.png"), :alt => "CC by-sa 2.0"
-    end
+    xhtml.a t(".feed.cc0"), :href => t(".feed.cc0_url")
   end
 
   @changesets.each do |changeset|

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -35,14 +35,16 @@
           <h2 class="flex-grow-1 mb-0"><%= t ".contribute_title" %></h2>
         </div>
         <p>
-          <%= t ".contribute_1_html", :wiki_link => link_to(t(".contribute_1_wiki"),
-                                                            t(".contribute_1_wiki_url")),
-                                      :forum_link => link_to(t(".contribute_1_forum"),
-                                                             "https://forum.openhistoricalmap.org/"),
-                                      :user_diaries_link => link_to(t(".contribute_1_user_diaries"),
-                                                                    diary_entries_path),
-                                      :mastodon_link => link_to(t(".contribute_1_mastodon"),
-                                                                "https://mapstodon.space/@ohm") %>
+          <%= t ".contribute_1_ohm_html", :wiki_link => link_to(t(".contribute_1_wiki"),
+                                                                t(".contribute_1_wiki_url")),
+                                          :forum_link => link_to(t(".contribute_1_forum"),
+                                                                 "https://forum.openhistoricalmap.org/"),
+                                          :user_diaries_link => link_to(t(".contribute_1_user_diaries"),
+                                                                        diary_entries_path),
+                                          :mastodon_link => link_to(t(".contribute_1_mastodon"),
+                                                                    "https://mapstodon.space/@ohm"),
+                                          :bluesky_link => link_to(t(".contribute_1_bluesky"),
+                                                                   "https://bsky.app/profile/openhistoricalmap.org") %>
         </p>
         <p>
           <%= t ".contribute_2_html", :create_account_link => link_to(t(".contribute_2_create_account"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,6 +464,8 @@ en:
       no_more_user: "No more changesets by this user."
       load_more: "Load more"
       feed:
+        cc0: Creative Commons CC0
+        cc0_url: https://creativecommons.org/publicdomain/zero/1.0/
         title: "Changeset %{id}"
         title_comment: "Changeset %{id} - %{comment}"
         created: "Created"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1937,15 +1937,16 @@ en:
         And you remember what your neighborhood used to look like.
         All of it belongs on OpenHistoricalMap.  
       contribute_title: You Can Help
-      contribute_1_html: |
+      contribute_1_ohm_html: |
         Our growing community of volunteer contributors includes amateur and professional historians, OpenStreetMap and Wikipedia contributors, GIS specialists, and ordinary people knowledgeable about their surroundings.
         We are passionate about documenting the world and helping real-world communities tell their stories.
-        To learn more about the community, consult %{wiki_link}, visit %{forum_link}, read the %{user_diaries_link}, and follow %{mastodon_link}.
+        To learn more about the community, consult %{wiki_link}, visit %{forum_link}, read the %{user_diaries_link}, and follow our %{mastodon_link} or %{bluesky_link} account.
+      contribute_1_bluesky: Bluesky
+      contribute_1_forum: our discussion forum
+      contribute_1_mastodon: Mastodon
+      contribute_1_user_diaries: user diaries
       contribute_1_wiki: our extensive wiki documentation
       contribute_1_wiki_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap
-      contribute_1_forum: our discussion forum
-      contribute_1_user_diaries: user diaries
-      contribute_1_mastodon: our Mastodon account
       contribute_2_html: |
         You can start contributing to the map today by %{create_account_link}.
         We also %{donations_link} through %{osmus_link}, a 501(c)(3) nonprofit organization with tax-exempt status.


### PR DESCRIPTION
This PR takes care of a couple of tail-work items from #279 and #282: the About page now links to our new Bluesky account, and the Atom feed of changesets states the license as CC0 rather than Creative Commons Attribution–ShareAlike. (This will conflict with openstreetmap/openstreetmap-website#5933, which changes it to ODbL.)

Fixes OpenHistoricalMap/issues#918.