### PR TITLE
Fix loading note by ID

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -32,97 +32,94 @@ OSM.Note = function (map) {
   };
 
   page.load = function (path, id) {
-    initialize(path, id);
-    moveToNote();
-    page.load = function () {
-      // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-      // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-      function originalLoadFunction() {
-        initialize(moveToNote);
-      }  // end originalLoadFunction
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction(path, id) {
+      initialize(path, id);
+      moveToNote();
+    }  // end originalLoadFunction
 
-      // "if map.timeslider" only try to add the timeslider if we don't already have it
-      if (map.timeslider) {
-        originalLoadFunction();
-      } else {
-        var params = querystring.parse(location.hash.substring(1));
-        addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-      }
-    };
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    } else {
+      var params = querystring.parse(location.hash.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
+  };
 
-    function initialize(path, id) {
-      content.find("button[type=submit]").on("click", function (e) {
-        e.preventDefault();
-        var data = $(e.target).data();
-        var form = e.target.form;
+  function initialize(path, id) {
+    content.find("button[type=submit]").on("click", function (e) {
+      e.preventDefault();
+      var data = $(e.target).data();
+      var form = e.target.form;
 
-        $(form).find("button[type=submit]").prop("disabled", true);
+      $(form).find("button[type=submit]").prop("disabled", true);
 
-        $.ajax({
-          url: data.url,
-          type: data.method,
-          oauth: true,
-          data: {text: $(form.text).val()},
-          success: function () {
-            OSM.loadSidebarContent(path, function () {
-              initialize(path, id);
-              moveToNote();
-            });
-          },
-          error: function (xhr) {
-            $(form).find("#comment-error")
-              .text(xhr.responseText)
-              .prop("hidden", false);
-            updateButtons(form);
-          }
-        });
+      $.ajax({
+        url: data.url,
+        type: data.method,
+        oauth: true,
+        data: {text: $(form.text).val()},
+        success: function () {
+          OSM.loadSidebarContent(path, function () {
+            initialize(path, id);
+            moveToNote();
+          });
+        },
+        error: function (xhr) {
+          $(form).find("#comment-error")
+          .text(xhr.responseText)
+          .prop("hidden", false);
+          updateButtons(form);
+        }
       });
+    });
 
-      content.find("textarea").on("input", function (e) {
-        updateButtons(e.target.form);
+    content.find("textarea").on("input", function (e) {
+      updateButtons(e.target.form);
+    });
+
+    content.find("textarea").val("").trigger("input");
+
+    var data = $(".details").data();
+
+    if (data) {
+      map.addObject({
+        type: "note",
+        id: parseInt(id, 10),
+        latLng: L.latLng(data.coordinates.split(",")),
+        icon: noteIcons[data.status]
       });
-
-      content.find("textarea").val("").trigger("input");
-
-      var data = $(".details").data();
-
-      if (data) {
-        map.addObject({
-          type: "note",
-          id: parseInt(id, 10),
-          latLng: L.latLng(data.coordinates.split(",")),
-          icon: noteIcons[data.status]
-        });
-      }
     }
-
-    function updateButtons(form) {
-      $(form).find("button[type=submit]").prop("disabled", false);
-      if ($(form.text).val() === "") {
-        $(form.close).text($(form.close).data("defaultActionText"));
-        $(form.comment).prop("disabled", true);
-      } else {
-        $(form.close).text($(form.close).data("commentActionText"));
-        $(form.comment).prop("disabled", false);
-      }
-    }
-
-    function moveToNote() {
-      var data = $(".details").data();
-      if (!data) return;
-      var latLng = L.latLng(data.coordinates.split(","));
-
-      if (!window.location.hash || window.location.hash.match(/^#?c[0-9]+$/)) {
-        OSM.router.withoutMoveListener(function () {
-          map.setView(latLng, 15, {reset: true});
-        });
-      }
-    }
-
-    page.unload = function () {
-      map.removeObject();
-    };
-
-    return page;
   }
+
+  function updateButtons(form) {
+    $(form).find("button[type=submit]").prop("disabled", false);
+    if ($(form.text).val() === "") {
+      $(form.close).text($(form.close).data("defaultActionText"));
+      $(form.comment).prop("disabled", true);
+    } else {
+      $(form.close).text($(form.close).data("commentActionText"));
+      $(form.comment).prop("disabled", false);
+    }
+  }
+
+  function moveToNote() {
+    var data = $(".details").data();
+    if (!data) return;
+    var latLng = L.latLng(data.coordinates.split(","));
+
+    if (!window.location.hash || window.location.hash.match(/^#?c[0-9]+$/)) {
+      OSM.router.withoutMoveListener(function () {
+        map.setView(latLng, 15, {reset: true});
+      });
+    }
+  }
+
+  page.unload = function () {
+    map.removeObject();
+  };
+
+  return page;
 };


### PR DESCRIPTION
Redid a botched merge of `OSM.Note` that effectively hid initialization code from history-pushing code. Most of the diff consists of unindenting code that had gotten nested one level too deep inside a method.

Fixes OpenHistoricalMap/issues#1044.