### PR TITLE
Localize labels based on language code only

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -66,19 +66,6 @@ L.OSM.layers = function (options) {
         layers.forEach(function (other) {
           if (other === layer) {
             map.addLayer(other);
-            // if (other.options.style.name.match(/^ohm/)) {
-            //   const language = new MapboxLanguage({
-            //     defaultLanguage: 'mul'
-            //   });
-            //   for (let i=0; i<OSM.preferred_languages.length; i++) {
-            //     if (language.supportedLanguages.includes(OSM.preferred_languages[i])) {
-            //       other.getMaplibreMap().setStyle(language.setLanguage(other.getMaplibreMap().getStyle(), OSM.preferred_languages[i]));
-            //       break
-            //     }
-            //   }
-            //
-            //   // console.info(`added to ${other.options.style.name}`)
-            // }
           } else {
             map.removeLayer(other);
           }

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -93,6 +93,11 @@ L.OSM.Map = L.Map.extend({
         selectedLanguage = navigator.language
       }
     }
+    if (selectedLanguage) {
+      // Strip out country and script codes. Country- and script-qualified language tags are relatively rare in OHM, and mapbox-gl-language lacks cascading fallback functionality.
+      // https://github.com/mapbox/mapbox-gl-language/issues/4
+      selectedLanguage = selectedLanguage.split("-")[0];
+    }
     console.info(`language:\n  preferred: ${OSM.preferred_languages}\n  browser: ${navigator.language}\n  using: ${selectedLanguage}`);
     language.supportedLanguages.push(selectedLanguage);
 


### PR DESCRIPTION
Strip any country and script codes from the locale code when localizing map labels. Since most user agents supply country codes, this will have the effect of making localized labels much more prevalent by default. However, it will regress Chinese and Serbian labels, since script codes are more or less expected for those languages. A proper fix will require either mapbox/mapbox-gl-language#4 or osm-americana/openstreetmap-americana#914.

Before | After
----|----
<img width="1024" alt="en-US preference, en-US labels" src="https://github.com/user-attachments/assets/3e4db21c-ccff-45e8-95e1-8c3c0ee99b60" /> | <img width="1024" alt="en-US preference, en labels" src="https://github.com/user-attachments/assets/d96dd635-6006-4a07-b041-b2c9d9fbddf6" />

Addresses the issue reported in https://github.com/OpenHistoricalMap/issues/issues/1068#issuecomment-2911950883 but not the broader issue.