### PR TITLE
Use sub as UID  from OIDC info

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -194,7 +194,7 @@ class UsersController < ApplicationController
 
     provider = auth_info[:provider]
     uid = auth_info[:uid]
-    name = auth_info[:info][:name]
+    name = provider.to_s == "openstreetmap" ? auth_info.dig(:extra, :raw_info, "preferred_username") : auth_info[:info][:name]
     email = auth_info[:info][:email]
 
     email_verified = case provider

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -32,7 +32,7 @@ osm_oidc_options = { :name => :openstreetmap,
                      :issuer => "https://www.openstreetmap.org",
                      :discovery => true,
                      :response_type => :code,
-                     :uid_field => "preferred_username",
+                     :uid_field => "sub",
                      :client_options => {
                        :port => 443,
                        :scheme => "https",


### PR DESCRIPTION
- Changes :uid_field from preferred_username to the OIDC standard sub field, as suggested in  https://github.com/OpenHistoricalMap/ohm-website/pull/284#issuecomment-2926742671
- Uses preferred_username (available via the read_prefs scope) to prefill the username in the /user/new form when using OSM authentication.

This improves user experience by reducing manual input, while ensuring consistent and unique user identification.


e.g
![image](https://github.com/user-attachments/assets/2619dd43-3b6b-467e-a9f1-3406577122ae)

- The username Rub21 was already taken in the database during testing.
- Also, just to confirm: using the read_prefs scope does not return the OSM user’s email address.

cc. @1ec5 @mmd-osm

