### PR TITLE
Bump map-styles version to 0.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@maplibre/maplibre-gl-leaflet": "^0.0.20",
-    "@openhistoricalmap/map-styles": "^0.9.6",
+    "@openhistoricalmap/map-styles": "^0.9.8",
     "@openhistoricalmap/maplibre-gl-language": "^0.1.0",
     "@types/leaflet": "^1.9.0",
     "bs-custom-file-input": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,10 +183,10 @@
     rw "^1.3.3"
     tinyqueue "^3.0.0"
 
-"@openhistoricalmap/map-styles@^0.9.6":
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/@openhistoricalmap/map-styles/-/map-styles-0.9.7.tgz#032819a4b432059fe61464a7412f5928900f8c25"
-  integrity sha512-ce1dWK/i6zWOOd//mw+aqZmzPwbZ7nwkCTe3qyUMlUZW9xgUeoS6nMza0bi7az74hsAnnOceRVT8BNtLlNO2WQ==
+"@openhistoricalmap/map-styles@^0.9.8":
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/@openhistoricalmap/map-styles/-/map-styles-0.9.8.tgz#0cbd054063015ebc575f236e718d20912fcd8ac4"
+  integrity sha512-cZ5RjTzLaQSSl23BSnxz4gqVeH3FulFlGhET7ZVH7wqX1IdHW+eggx2aye07i7J0Bf/RsBKg1JNm/AsInVnGTg==
   dependencies:
     camelcase "^8.0.0"
     fs-extra "^11.3.0"
@@ -198,10 +198,6 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@openhistoricalmap/maplibre-gl-language/-/maplibre-gl-language-0.1.0.tgz#83866730bcaa234dde81a198e9c1caa47e105330"
   integrity sha512-Y6wqUKK2piGOYjj2pJ7szz3HhtvWTZpnvebhmi4ghLbss9FyGOMGgVIRQ46tiqV5f5g/QMtKqotybKdejk6e6g==
-
-"@openhistoricalmap/maplibre-gl-language@openhistoricalmap/maplibre-gl-language":
-  version "0.1.0"
-  resolved "https://codeload.github.com/openhistoricalmap/maplibre-gl-language/tar.gz/a1f4c7b070e96aa5092c7dff79a2fdabd61b2055"
 
 "@types/estree@^1.0.6":
   version "1.0.7"


### PR DESCRIPTION
Version update for our map-styles npm module; changes only to `package.json` and `yarn.lock`. This will independently be deployed to production, bypassing the usual flow, as the staging branch is not fully tested.