### PR TITLE
Enable standard attribution sans "Leaflet" prefix on user dashboard map

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -12,9 +12,10 @@ $(document).ready(function () {
 
   if ($("#map").length) {
     map = L.map("map", {
-      attributionControl: false,
+      attributionControl: true,
       zoomControl: false
     }).addLayer(new L.OSM.Mapnik());
+    map.attributionControl.setPrefix(false);
 
     var position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
 


### PR DESCRIPTION
Addresses: https://github.com/OpenHistoricalMap/issues/issues/1027#issuecomment-2943350458

It's a less wide map so I'm leaving out the donation, terms, and API links that are found on the homepage's Standard layer.

![image](https://github.com/user-attachments/assets/a5dd5fe5-13ba-412f-91ea-8886b0747c56)
