### PR TITLE
Update e-mail addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ If a community member engages in unacceptable behavior, the community organizers
 
 ## 7. Reporting Guidelines
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. ohm-admins@googlegroups.com.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible at admin@openhistoricalmap.org.
 
 
 
@@ -77,7 +77,7 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ## 10. Contact info
 
-historic@openstreetmap.org
+admin@openhistoricalmap.org
 
 ## 11. License and attribution
 

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -98,7 +98,7 @@
                                                                  t(".legal_1_privacy_policy_url")) %>
         </p>
         <p>
-          <%= t ".legal_2_html", :contact_team_link => mail_to(Settings.support_email,
+          <%= t ".legal_2_html", :contact_team_link => mail_to(Settings.legal_email,
                                                                t(".legal_2_contact_team")) %>
         </p>
         <p>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -132,10 +132,8 @@
     <p><%= t ".legal_babble.infringement_1_html" %></p>
     <p>
       <%= t ".legal_babble.infringement_2_ohm_html",
-            # Leave the subject untranslated so we know it’s urgent.
-            :contact_team_link => mail_to(Settings.support_email,
-                                          t(".legal_babble.infringement_2_ohm_contact_team"),
-                                          :subject => "TAKEDOWN REQUEST"),
+            :contact_team_link => mail_to(Settings.legal_email,
+                                          t(".legal_babble.infringement_2_ohm_contact_team")),
             :subject => tag.q("TAKEDOWN REQUEST", :lang => "en", :dir => "ltr") %>
     </p>
 
@@ -144,7 +142,7 @@
     </h3>
     <p>
       <%= t ".legal_babble.trademarks_1_ohm_html",
-            :contact_team_link => mail_to(Settings.support_email,
+            :contact_team_link => mail_to(Settings.legal_email,
                                           t(".legal_babble.trademarks_1_ohm_contact_team")) %>
     </p>
   <% end %>

--- a/config/example.settings.local.yml
+++ b/config/example.settings.local.yml
@@ -14,7 +14,7 @@ max_number_of_nodes: 100000
 api_timeout: 600
 web_timeout: 600
 #memcache_servers: []
-nominatim_url: "https://nominatim-api.openhistoricalmap.org/"
+nominatim_url: "https://nominatim.openhistoricalmap.org/"
 # OAuth application for the website
 oauth_application: ""
 oauth_key: ""

--- a/config/example.settings.local.yml
+++ b/config/example.settings.local.yml
@@ -6,9 +6,10 @@ embed_server_url: "https://embed.openhistoricalmap.org/"
 generator: "OpenHistoricalMap server"
 copyright_owner: "OpenHistoricalMap and contributors"
 attribution_url: "http://www.openhistoricalmap.org/copyright"
-support_email: "ohm-admins@googlegroups.com"
-email_from: "OpenHistoricalMap <ohm-admins@googlegroups.com>"
-email_return_path: "ohm-admins@googlegroups.com"
+legal_email: "legal@openhistoricalmap.org"
+support_email: "dev@openhistoricalmap.org"
+email_from: "OpenHistoricalMap <web@noreply.openhistoricalmap.org>"
+email_return_path: "bounces@openhistoricalmap.org"
 max_number_of_nodes: 100000
 api_timeout: 600
 web_timeout: 600

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,8 +8,10 @@ generator: "OpenStreetMap server"
 copyright_owner: "OpenStreetMap and contributors"
 attribution_url: "http://www.openstreetmap.org/copyright"
 license_url: "http://opendatacommons.org/licenses/odbl/1-0/"
+# Legal email address
+legal_email: "legal@openhistoricalmap.org"
 # Support email address
-support_email: "openstreetmap@example.com"
+support_email: "dev@openhistoricalmap.org"
 # Sender addresses for emails
 email_from: "OpenStreetMap <openstreetmap@example.com>"
 email_return_path: "openstreetmap@example.com"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,7 +110,7 @@ attachments_dir: ":rails_root/public/attachments"
 # List of memcache servers to use for caching
 #memcache_servers: []
 # URL of Nominatim instance to use for geocoding
-nominatim_url: "https://nominatim.openstreetmap.org/"
+nominatim_url: "https://nominatim-api.openhistoricalmap.org/"
 # Default editor
 default_editor: "id"
 # OAuth application for the web site
@@ -120,7 +120,7 @@ default_editor: "id"
 # Imagery to return in capabilities as blacklisted
 imagery_blacklist: []
 # URL of Overpass instance to use for feature queries
-overpass_url: "https://overpass-api.de/api/interpreter"
+overpass_url: "https://overpass-api.openhistoricalmap.org/api/interpreter"
 overpass_credentials: false
 # Routing endpoints
 graphhopper_url: "https://graphhopper.com/api/1/route"


### PR DESCRIPTION
Updated e-mail addresses to use the new @openhistoricalmap.org addresses. Also updated some references to the Nominatim and Overpass endpoints.

Working towards OpenHistoricalMap/issues#298 and OpenHistoricalMap/issues#1001.