### PR TITLE
Restore message customizations

### DIFF
--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -16,7 +16,7 @@
       <circle cx="50" cy="50" r="45" fill="#70cd8f" />
       <path d="M31 46h-2l-3 3v2l14 14 5 5 5-5 25-25v-2l-3-3h-2l-25 25z" fill="#fff" />
     </svg>
-    <p><%= t ".whats_on_the_map.on_the_map_html", :real_and_current => tag.em(t(".whats_on_the_map.real_and_current")) %></p>
+    <p><%= t ".whats_on_the_map.on_the_map_ohm_html", :past_and_present => tag.em(t(".whats_on_the_map.past_and_present")) %></p>
   </div>
   <div class='col-sm'>
     <svg width='50' height='50' viewBox='0 0 100 100' class='d-block mx-auto'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,10 +298,10 @@ en:
         title: Delete My Account
         warning: Warning! The account deletion process is final, and cannot be reversed.
         delete_account: Delete Account
-        delete_introduction: "You can delete your OpenStreetMap account using the button below. Please note the following details:"
+        delete_introduction: "You can delete your OpenHistoricalMap account using the button below. Please note the following details:"
         delete_profile: Your profile information, including your avatar, description and home location will be removed.
         delete_display_name: Your display name will be removed, and can be reused by other accounts.
-        retain_caveats: "However, some information about you will be retained on OpenStreetMap, even after your account is deleted:"
+        retain_caveats: "However, some information about you will be retained on OpenHistoricalMap, even after your account is deleted:"
         retain_edits: Your edits to the map database, if any, will be retained.
         retain_traces: Your uploaded traces, if any, will be retained.
         retain_diary_entries: Your diary entries and diary comments, if any, will be retained but hidden from view.
@@ -319,7 +319,7 @@ en:
         read and accept with tou: "Please read the contributor agreement and the terms of use, check both checkboxes when done and then press the continue button."
         contributor_terms_explain: "This agreement governs the terms for your existing and future contributions."
         read_ct: "I have read and agree to the above contributor terms"
-        tou_explain_html: "These %{tou_link} govern the use of the website and other infrastructure provided by the OSMF. Please click on the link, read and agree to the text."
+        tou_explain_html: "These %{tou_link} govern the use of the website and other infrastructure provided by OpenHistoricalMap. Please click on the link, read and agree to the text."
         read_tou: "I have read and agree to the Terms of Use"
         guidance_info_html: "Information to help understand these terms: a %{readable_summary_link} and some %{informal_translations_link}"
         readable_summary: human readable summary
@@ -654,7 +654,7 @@ en:
         description: "Recent diary entries from users of OpenHistoricalMap"
     comments:
       title: "OpenHistoricalMap diary entries"
-      description: "Recent diary entries from users of OpenStreetMap"
+      description: "Recent diary entries from users of OpenHistoricalMap"
     subscribe:
       heading: Subscribe to the following diary entry discussion?
       button: Subscribe to discussion
@@ -1746,8 +1746,8 @@ en:
     learn_more: "Learn More"
     more: More
     offline_flash:
-      osm_offline: "The OpenStreetMap database is currently offline while essential maintenance work is carried out."
-      osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential maintenance work is carried out."
+      osm_offline: "The OpenHistoricalMap database is currently offline while essential maintenance work is carried out."
+      osm_read_only: "The OpenHistoricalMap database is currently in read-only mode while essential maintenance work is carried out."
       expected_restore_html: "Services are expected to be restored in %{time}."
       announcement: "You can read the announcement here."
   user_mailer:
@@ -1815,7 +1815,7 @@ en:
       hopefully_you: "Someone (possibly you) has asked for the password to be reset on this email address's openhistoricalmap.org account."
       click_the_link: "If this is you, please click the link below to reset your password."
     note_comment_notification:
-      description: "OpenStreetMap Note #%{id}"
+      description: "OpenHistoricalMap Note #%{id}"
       anonymous: An anonymous user
       greeting: "Hi,"
       commented:
@@ -1842,7 +1842,7 @@ en:
       details: "Reply or learn more about the note at %{url}."
       details_html: "Reply or learn more about the note at %{url}."
     changeset_comment_notification:
-      description: "OpenStreetMap Changeset #%{id}"
+      description: "OpenHistoricalMap Changeset #%{id}"
       hi: "Hi %{to_user},"
       commented:
         subject_own: "[OpenHistoricalMap] %{commenter} has commented on one of your changesets"
@@ -2039,7 +2039,7 @@ en:
   sessions:
     new:
       tab_title: "Log In"
-      login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
+      login_to_authorize_html: "Log in to OpenHistoricalMap to access %{client_app_name}."
       already_logged_in_html: "You are already logged in as %{user}. Logging in again will change your current account."
       access_another_page: "You arrived here while trying to access another page. If you want to access that page using your current account, click the button below:"
       visit_referring_page: "Visit referring page"
@@ -2223,7 +2223,7 @@ en:
         more_1_wiki: on the OpenStreetMap Wiki
         more_1_wiki_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/License
         more_2_1_html: |
-          Although OpenStreetMap is open data, we cannot provide a
+          Although OpenHistoricalMap is open data, we cannot provide a
           free-of-charge map API or map tiles for third-parties.
           See our %{api_usage_policy_link}, %{tile_usage_policy_link} and %{nominatim_usage_policy_link}.
         more_2_1_api_usage_policy: API Usage Policy
@@ -2333,7 +2333,6 @@ en:
           title: Join the community
           explanation_html: |
             If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
-            proceed is to join the OpenStreetMap community and add or repair the data yourself.
             proceed is to join the OpenHistoricalMap community and add or repair the data yourself.
         add_a_note:
           instructions_1_html: |
@@ -2356,7 +2355,7 @@ en:
       welcome:
         url: /welcome
         title: Welcome to OpenHistoricalMap
-        description: Start with this quick guide covering the OpenStreetMap basics.
+        description: Start with this quick guide covering the OpenHistoricalMap basics.
       beginners_guide:
         url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
         title: Beginners' Guide
@@ -2408,7 +2407,7 @@ en:
         title: Wiki
         description: Community-maintained instructions for using OHM and guidelines for contributing to the project.
     potlatch:
-      removed: Your default OpenStreetMap editor is set as Potlatch. Because Adobe Flash Player has been withdrawn, Potlatch is no longer available to use in a web browser.
+      removed: Your default OpenHistoricalMap editor is set as Potlatch. Because Adobe Flash Player has been withdrawn, Potlatch is no longer available to use in a web browser.
       desktop_application_html: You can still use Potlatch by %{download_link}.
       download: downloading the desktop application for Mac and Windows
       download_url: https://www.systemed.net/potlatch/
@@ -2445,29 +2444,29 @@ en:
     welcome:
       title: Welcome!
       introduction: |
-        Welcome to OpenStreetMap, the free and editable map of the world. Now that you're signed
+        Welcome to OpenHistoricalMap, the free and editable map of world history. Now that you're signed
         up, you're all set to get started mapping. Here's a quick guide with the most important
         things you need to know.
       whats_on_the_map:
         title: What's on the Map
-        on_the_map_html: |
-          OpenStreetMap is a place for mapping things that are both %{real_and_current} -
-          it includes millions of buildings, roads, and other details about places. You can map
-          whatever real-world features are interesting to you.
-        real_and_current: real and current
+        on_the_map_ohm_html: |
+          OpenHistoricalMap tracks changes to natural and human geography throughout the world.
+          We have millions of entries from %{past_and_present}, from empires and glaciers to houses and restaurants.
+          You can map whatever real-world features are interesting to you.
+        past_and_present: both the past and present
         off_the_map_html: |
-          What it %{doesnt} include is opinionated data like ratings, historical or
-          hypothetical features, and data from copyrighted sources. Unless you have special
-          permission, don't copy from online or paper maps.
+          OpenHistoricalMap %{doesnt} include fictional alternative histories,
+          known errors from antique maps, and data from copyrighted sources. Unless you have special
+          permission, don't copy from modern maps of the past that you find online or in print.
         doesnt: doesn't
       basic_terms:
         title: Basic Terms For Mapping
         paragraph_1: |
-          OpenStreetMap has some of its own lingo. Here are a few key words that'll come in handy.
+          OpenHistoricalMap has some of its own lingo. Here are a few key words that'll come in handy.
         an_editor_html: An %{editor} is a program or website you can use to edit the map.
         a_node_html: A %{node} is a point on the map, like a single restaurant or a tree.
         a_way_html: A %{way} is a line or area, like a road, stream, lake or building.
-        a_tag_html: A %{tag} is a bit of data about a node or way, like a restaurant's name or a road's speed limit.
+        a_tag_html: A %{tag} is a bit of data about a node or way, like a restaurant's name or the year a bridge was built.
         editor: editor
         node: node
         way: way
@@ -2475,7 +2474,7 @@ en:
       rules:
         title: Rules!
         para_1_html: |
-          OpenStreetMap has few formal rules but we expect all participants to collaborate
+          OpenHistoricalMap has few formal rules but we expect all participants to collaborate
           with, and communicate with, the community. If you are considering
           any activities other than editing by hand, please read and follow the guidelines on
           %{imports_link} and %{automated_edits_link}.
@@ -2498,7 +2497,7 @@ en:
     communities:
       title: Communities
       lede_text: |
-        People from all over the world contribute to or use OpenStreetMap.
+        People from all over the world contribute to or use OpenHistoricalMap.
         While many participate as individuals, others have formed communities.
         These groups come in a range of sizes and represent geographies from small towns to large multi-country regions.
         They can also be formal or informal.
@@ -2769,7 +2768,7 @@ en:
     permissions:
       missing: "You have not permitted the application access to this facility"
     scopes:
-      openid: Sign in using OpenStreetMap
+      openid: Sign in using OpenHistoricalMap
       read_prefs: Read user preferences
       write_prefs: Modify user preferences
       write_diary: Create diary entries and comments
@@ -2838,7 +2837,7 @@ en:
     new:
       title: "Sign Up"
       tab_title: "Sign Up"
-      signup_to_authorize_html: "Sign up with OpenStreetMap to access %{client_app_name}."
+      signup_to_authorize_html: "Sign up with OpenHistoricalMap to access %{client_app_name}."
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
       please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
       support: support
@@ -2850,7 +2849,7 @@ en:
         paragraph_2: |
           Sign up to get started contributing. We'll send an email to confirm your account.
         welcome: "Welcome to OpenHistoricalMap"
-      duplicate_social_email: "If you already have an OpenStreetMap account and wish to use a 3rd party identity provider, please log in using your password and modify the settings of your account."
+      duplicate_social_email: "If you already have an OpenHistoricalMap account and wish to use a 3rd party identity provider, please log in using your password and modify the settings of your account."
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       by_signing_up:
         html: "By signing up, you agree to our %{tou_link}, %{privacy_policy_link} and %{contributor_terms_link}."
@@ -3215,12 +3214,12 @@ en:
         url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
       counter_warning_forum_link:
         text: "the community can help you"
-        url: https://community.openstreetmap.org/
+        url: https://forum.openhistoricalmap.org/
       advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
       add: Add Note
     new_readonly:
       title: "New Note"
-      warning: "New notes cannot be created because the OpenStreetMap API is currently in read-only mode."
+      warning: "New notes cannot be created because the OpenHistoricalMap API is currently in read-only mode."
     notes_paging_nav:
       showing_page: "Page %{page}"
       next: "Next"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3285,7 +3285,7 @@ en:
         overlays: Enable overlays for troubleshooting the map
         title: "Layers"
       copyright_text: "© %{copyright_link}"
-      openstreetmap_contributors: "OpenStreetMap contributors"
+      openstreetmap_contributors: "OpenHistoricalMap contributors"
       cc0_text: "%{copyright_link}"
       openhistoricalmap_contributors: "OHM"
       make_a_donation: Make a Donation


### PR DESCRIPTION
Restored numerous references to OpenHistoricalMap that have gotten clobbered by OpenStreetMap in a recent merge. Also rewrote the copy on the Welcome page to focus on the kinds of stuff we map in OHM.

Fixes OpenHistoricalMap/issues#1110.