### PR TITLE
Fix OHM layer switching

### DIFF
--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -47,7 +47,7 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
     onreadycallback();
   }
 
-  map.on('baselayerchange layeradd', function () {
+  map.on('baselayerchange', function () {
     // do not use this.removeControl(this.timeslider)
     // by now, the timeslider is already gone from the visible map, along with the MBGL map
     // but the Leaflet wrapper will leave behind an empty DIV, and those pile up

--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -27,7 +27,7 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
       Cookies.set("_ohm_timeslider_daterange", map.timeslider.getRange().join(","), dateCookieOptions);
     },
     onReady: function () {
-      OSM.router.updateHash('force');
+      OSM.router.updateHash(null, true /* force */);
     },
     position: 'bottomright',
   };

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -65,41 +65,43 @@ L.OSM.Map = L.Map.extend({
     // console.info(`language:\n  preferred: ${OSM.preferred_languages}\n  browser: ${navigator.language}\n  using: ${selectedLanguage}`);
     language.supportedLanguages.push(selectedLanguage);
 
-    this.baseLayers.unshift(new L.MaplibreGL(
-      Object.assign(this.ohmMaplibreOptions, {
-        code: "J",
-        keyid: "japanese",
-        name: OSM.i18n.t("javascripts.map.base.japanesescroll"),
-        style: language.setLanguage(ohmVectorStyles.JapaneseScroll, selectedLanguage),
-      })
-    ));
-
-    this.baseLayers.unshift(new L.MaplibreGL(
-      Object.assign(this.ohmMaplibreOptions, {
-        code: "W",
-        keyid: "woodblock",
-        name: OSM.i18n.t("javascripts.map.base.woodblock"),
-        style: language.setLanguage(ohmVectorStyles.Woodblock, selectedLanguage),
-      })
-    ));
-
-    this.baseLayers.unshift(new L.MaplibreGL(
-      Object.assign(this.ohmMaplibreOptions, {
-        code: "R",
-        keyid: "railway",
-        name: OSM.i18n.t("javascripts.map.base.railway"),
-        style: language.setLanguage(ohmVectorStyles.Railway, selectedLanguage),
-      })
-    ));
-
-    this.baseLayers.unshift(new L.MaplibreGL(
-      Object.assign(this.ohmMaplibreOptions, {
+    let ohmLayerOptions = [
+      {
         code: "O",
         keyid: "historical",
         name: OSM.i18n.t("javascripts.map.base.historical"),
-        style: language.setLanguage(ohmVectorStyles.Historical, selectedLanguage)
-      })
-    ));
+        style: ohmVectorStyles.Historical,
+      },
+      {
+        code: "R",
+        keyid: "railway",
+        name: OSM.i18n.t("javascripts.map.base.railway"),
+        style: ohmVectorStyles.Railway,
+      },
+      {
+        code: "W",
+        keyid: "woodblock",
+        name: OSM.i18n.t("javascripts.map.base.woodblock"),
+        style: ohmVectorStyles.Woodblock,
+      },
+      {
+        code: "J",
+        keyid: "japanese",
+        name: OSM.i18n.t("javascripts.map.base.japanesescroll"),
+        style: ohmVectorStyles.JapaneseScroll,
+      },
+    ];
+
+    this.baseLayers.unshift(...ohmLayerOptions.map(layerOptions => {
+      layerOptions.style = language.setLanguage(layerOptions.style, selectedLanguage);
+      let layer = new L.MaplibreGL(
+        Object.assign(this.ohmMaplibreOptions, layerOptions)
+      );
+      layer.on("add", () => {
+        this.fire("baselayerchange", { layer: layer });
+      });
+      return layer;
+    }));
 
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = { code: "N" };

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -146,7 +146,7 @@ OSM.Router = function (map, rts) {
     window.history.replaceState(state, document.title, url);
   };
 
-  router.updateHash = function(force) {
+  router.updateHash = function(event, force) {
     var hash = OSM.formatHash(map);
     if (hash === currentHash && !force) return;
     currentHash = hash;


### PR DESCRIPTION
Refactored OHM layer definitions to reduce repetition. Hook up the OHM layers to the `baselayerchange` event instead of listening for the `layeradd` event.

Fixes OpenHistoricalMap/issues#1111 and fixes OpenHistoricalMap/issues#1115 and fixes OpenHistoricalMap/issues#1104 a different way.