### PR TITLE
Fix OpenStreetMap authentication provider icon

### DIFF
--- a/app/assets/images/auth_providers/openstreetmap.svg
+++ b/app/assets/images/auth_providers/openstreetmap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="256" height="256">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="256" height="256" viewbox="0 0 256 256">
   <style><![CDATA[.B{opacity:.387}.C{fill:#ceeeab}.D{fill-opacity:1}.E{stroke:none}.F{fill:none}.G{stroke-linejoin:round}.H{stroke-linecap:round}.I{stroke:#6d7f42}.J{opacity:.039}.K{fill:#2d3335}]]></style>
   <defs>
     <linearGradient id="A" xlink:href="#As">


### PR DESCRIPTION
@Rub21 noticed that the button for logging in using an OpenStreetMap account had a truncated icon on staging following #316. This adjusts the image’s viewbox so the full icon shows but is scaled to fit the button. It’s still a very complex image, so hopefully browsers can display it well. I only tested it on Firefox.

Before | After
----|----
<img width="96" height="98" alt="Green trapezoid" src="https://github.com/user-attachments/assets/568e87da-812e-4ee6-8310-b851f151ab0e" /> | <img width="96" height="98" alt="Full OSM logo" src="https://github.com/user-attachments/assets/b0cacecd-b919-4070-b107-f3cf718ea514" />
