### PR TITLE
Fix map issues in non-English locales

### DIFF
--- a/app/assets/javascripts/leaflet.maplibre.js
+++ b/app/assets/javascripts/leaflet.maplibre.js
@@ -1,7 +1,7 @@
 //= require maplibre-gl
 //= require @maplibre/maplibre-gl-leaflet
 
-maplibregl.setRTLTextPlugin(OSM.RTL_TEXT_PLUGIN, true);
+// maplibregl.setRTLTextPlugin(OSM.RTL_TEXT_PLUGIN, true);
 
 L.OSM.MaplibreGL = L.MaplibreGL.extend({
   getAttribution: function () {

--- a/app/assets/javascripts/leaflet.ohm.js
+++ b/app/assets/javascripts/leaflet.ohm.js
@@ -1,7 +1,11 @@
 L.OSM.OHM = L.OSM.MaplibreGL.extend({
   onAdd: function (map) {
+    const styleName = (this.options.layerId || this.options.name?.replaceAll(' ', ''))
+      .trim()
+      .replace(/\w\S*/g, w => w[0].toUpperCase() + w.slice(1).toLowerCase());
+
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    this.getMaplibreMap().setStyle(ohmVectorStyles[this.options.name.replaceAll(' ','')]);
+    this.getMaplibreMap().setStyle(ohmVectorStyles[styleName]);
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);


### PR DESCRIPTION
The issue was that when we changed the language, the layer name—used to select the map style—would also change. Since we don’t manage map styles separately for different languages, it was better to use the layerId instead.

cc. @1ec5 @erictheise @jeffreyameyer 
Fixes https://github.com/OpenHistoricalMap/issues/issues/1127
