### PR TITLE
Fix slippy map when layer names are translated

### DIFF
--- a/app/assets/javascripts/leaflet.ohm.js
+++ b/app/assets/javascripts/leaflet.ohm.js
@@ -1,18 +1,14 @@
 L.OSM.OHM = L.OSM.MaplibreGL.extend({
   onAdd: function (map) {
-    const styleName = (this.options.layerId || this.options.name?.replaceAll(' ', ''))
-      .trim()
-      .replace(/\w\S*/g, w => w[0].toUpperCase() + w.slice(1).toLowerCase());
-
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    this.getMaplibreMap().setStyle(ohmVectorStyles[styleName]);
+    this.getMaplibreMap().setStyle(ohmVectorStyles[this.ohmStyleName]);
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);
   }
 });
 
-L.OSM.Historical = L.OSM.OHM.extend({});
-L.OSM.Railway = L.OSM.OHM.extend({});
-L.OSM.Woodblock = L.OSM.OHM.extend({});
-L.OSM.JapaneseScroll = L.OSM.OHM.extend({});
+L.OSM.Historical = L.OSM.OHM.extend({ ohmStyleName: "Historical" });
+L.OSM.Railway = L.OSM.OHM.extend({ ohmStyleName: "Railway"});
+L.OSM.Woodblock = L.OSM.OHM.extend({ ohmStyleName: "Woodblock" });
+L.OSM.JapaneseScroll = L.OSM.OHM.extend({ ohmStyleName: "JapaneseScroll" });

--- a/app/assets/javascripts/leaflet.ohm.js
+++ b/app/assets/javascripts/leaflet.ohm.js
@@ -1,7 +1,11 @@
 L.OSM.OHM = L.OSM.MaplibreGL.extend({
   onAdd: function (map) {
+    const styleName = (this.options.layerId || this.options.name?.replaceAll(' ', ''))
+      .trim()
+      .replace(/\w\S*/g, w => w[0].toUpperCase() + w.slice(1).toLowerCase());
+
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    this.getMaplibreMap().setStyle(ohmVectorStyles[this.options.name.replaceAll(' ','')]);
+    this.getMaplibreMap().setStyle(ohmVectorStyles[styleName]);
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);


### PR DESCRIPTION
When initializing each of the OHM-specific map layers, hard-code the key to look up in the `ohmVectorStyles` object of map styles vended by the map-styles package.

`ohmVectorStyles` keys on CamelCase IDs corresponding to the `leafletOsmId` property of each entry in layers.yml. Unfortunately, `L.OSM.Map.initialize()` doesn’t pass this property along to each layer constructor. #319 attempted to reconstruct a key from the `layerId`, but it didn’t work for multiword names like `JapaneseScroll`. Besides, there’s no guarantee that these IDs align.

Ideally, we’d be using the lowercase ID everywhere, so that the map-styles package aligns with the `layerId`s in layers.yml. But fundamentally, each layer should know which map-styles key it corresponds to anyways. There’s no sense in an `L.OSM.JapaneseScroll` being initialized with the Woodblock style JSON, for instance.

Fixes OpenHistoricalMap/issues#1127.