### PR TITLE
Restore inspector integration

### DIFF
--- a/app/assets/javascripts/index/element.js
+++ b/app/assets/javascripts/index/element.js
@@ -48,6 +48,8 @@
           });
         }
       });
+
+      addOpenHistoricalMapInspector();
     };
 
     page._removeObject = function () {
@@ -161,5 +163,20 @@
       }
     }
     return $("<tr>").append(cell);
+  }
+
+  // add the enhanced inspector
+  function addOpenHistoricalMapInspector() {
+    var inspector = new openhistoricalmap.OpenHistoricaMapInspector({
+      debug: true,
+      onFeatureFail: function (type, id) {
+        console.log([ 'failed to load feature', type, id ]);
+      },
+      onFeatureLoaded: function (type, id, xmldoc) {
+        console.log([ 'loaded feature', type, id, xmldoc ]);
+      },
+      apiBaseUrl: "/api",  // no trailing /
+    });
+    inspector.selectFeatureFromUrl();
   }
 }());


### PR DESCRIPTION
Restored a bit of code for initializing the inspector that was inadvertently removed in d50f381e4e26396367bd6415dfae0857853c64ab for #316.

Fixes OpenHistoricalMap/issues#1170.