### PR TITLE
Fix spelling of emirate

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1605,7 +1605,7 @@ en:
         district: "District Boundary"
         distrito: "District Boundary"
         dominion: "Dominion Boundary"
-        emirate: "Empirate Boundary"
+        emirate: "Emirate Boundary"
         empire: "Imperial Boundary"
         eyalet: "Eyalet Boundary"
         federal_district: "Federal District Boundary"


### PR DESCRIPTION
Fixed a typo for “emirate” introduced in #310.