### PR TITLE
Restore map localization, attribution, embedding

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -16,7 +16,8 @@ L.OSM.Map = L.Map.extend({
     this.baseLayers = OSM.LAYER_DEFINITIONS.map((
       { credit, nameId, leafletOsmId, leafletOsmDarkId, ...layerOptions }
     ) => {
-      if (credit) layerOptions.attribution = makeAttribution(credit);
+      let isOhm = layerOptions.source === 'openhistoricalmap';
+      if (credit) layerOptions.attribution = makeAttribution(credit, isOhm);
       if (nameId) layerOptions.name = OSM.i18n.t(`javascripts.map.base.${nameId}`);
       const layerConstructor =
         (OSM.isDarkMap() && L.OSM[leafletOsmDarkId]) ||
@@ -29,54 +30,6 @@ L.OSM.Map = L.Map.extend({
       });
       return layer;
     });
-
-    const credit = { 'id': 'make_a_donation', 'href': 'https://openstreetmap.app.neoncrm.com/forms/ohm', 'donate': true }
-    this.ohmMaplibreOptions = {
-      attribution: makeAttribution(credit, true),
-      localIdeographFontFamily: "'Noto Sans', 'Noto Sans CJK SC', sans-serif",
-      minZoom: 1,  /* leave at 1 even if L.OSM.Map has something deeper */
-      maxZoom: 20,  /* match to "L.OSM.Map" options in index.js */
-    }
-
-    /* see also timeslider.js and viewreset/baselayerchange handlers */
-
-    // Add multi-lingual awareness
-    const language = new MapboxLanguage({
-      defaultLanguage: 'mul'
-    });
-    let selectedLanguage;
-    /*
-     * Note: there is no language validation at this step; OSM.preferred_languages[0] may be any arbitrary string. Even
-     * if it is a valid (RFC 5646) language string it may be filtered out for being infrequently used
-     * (see https://github.com/OpenHistoricalMap/issues/issues/948) and may not appear on the OHM map.
-     */
-    if (OSM.preferred_languages !== undefined && OSM.preferred_languages.length > 0) {
-      selectedLanguage = OSM.preferred_languages[0]
-    } else {
-      if (navigator.language) {
-        selectedLanguage = navigator.language
-      }
-    }
-    if (selectedLanguage) {
-      // Strip out country and script codes. Country- and script-qualified language tags are relatively rare in OHM, and mapbox-gl-language lacks cascading fallback functionality.
-      // https://github.com/mapbox/mapbox-gl-language/issues/4
-      selectedLanguage = selectedLanguage.split("-")[0];
-    }
-    // console.info(`language:\n  preferred: ${OSM.preferred_languages}\n  browser: ${navigator.language}\n  using: ${selectedLanguage}`);
-    language.supportedLanguages.push(selectedLanguage);
-
-    let ohmLayerOptions = [];
-
-    this.baseLayers.unshift(...ohmLayerOptions.map(layerOptions => {
-      layerOptions.style = language.setLanguage(layerOptions.style, selectedLanguage);
-      let layer = new L.MaplibreGL(
-        Object.assign(this.ohmMaplibreOptions, layerOptions)
-      );
-      layer.on("add", () => {
-        this.fire("baselayerchange", { layer: layer });
-      });
-      return layer;
-    }));
 
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = { code: "N" };

--- a/app/assets/javascripts/leaflet.ohm.js
+++ b/app/assets/javascripts/leaflet.ohm.js
@@ -1,7 +1,40 @@
 L.OSM.OHM = L.OSM.MaplibreGL.extend({
+  initialize: function (options) {
+    L.OSM.MaplibreGL.prototype.initialize.call(this, {
+      localIdeographFontFamily: "'Noto Sans', 'Noto Sans CJK SC', sans-serif",
+      minZoom: 1, // leave at 1 even if L.OSM.Map has something deeper
+      maxZoom: 20, // match to "L.OSM.Map" options in index.js
+      ...options,
+    });
+  },
   onAdd: function (map) {
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    this.getMaplibreMap().setStyle(ohmVectorStyles[this.ohmStyleName]);
+
+    // Add multilingual awareness
+    const language = new MapboxLanguage({
+      defaultLanguage: 'mul'
+    });
+    let selectedLanguage;
+    /*
+     * Note: there is no language validation at this step; OSM.preferred_languages[0] may be any arbitrary string. Even
+     * if it is a valid (RFC 5646) language string it may be filtered out for being infrequently used
+     * (see https://github.com/OpenHistoricalMap/issues/issues/948) and may not appear on the OHM map.
+     */
+    if (OSM.preferred_languages !== undefined && OSM.preferred_languages.length > 0) {
+      selectedLanguage = OSM.preferred_languages[0]
+    } else if (navigator.language) {
+      selectedLanguage = navigator.language
+    }
+    if (selectedLanguage) {
+      // Strip out country and script codes. Country- and script-qualified language tags are relatively rare in OHM, and mapbox-gl-language lacks cascading fallback functionality.
+      // https://github.com/mapbox/mapbox-gl-language/issues/4
+      selectedLanguage = selectedLanguage.split("-")[0];
+    }
+    // console.info(`language:\n  preferred: ${OSM.preferred_languages}\n  browser: ${navigator.language}\n  using: ${selectedLanguage}`);
+    language.supportedLanguages.push(selectedLanguage);
+    let style = language.setLanguage(ohmVectorStyles[this.ohmStyleName], selectedLanguage);
+
+    this.getMaplibreMap().setStyle(style);
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -2,6 +2,7 @@
   code: "O"
   layerId: "historical"
   nameId: "historical"
+  canEmbed: true
   source: openhistoricalmap
   credit:
     id: 'make_a_donation'
@@ -12,6 +13,7 @@
   code: "R"
   layerId: "railway"
   nameId: "railway"
+  canEmbed: true
   source: openhistoricalmap
   credit:
     id: 'make_a_donation'
@@ -22,6 +24,7 @@
   code: "W"
   layerId: "woodblock"
   nameId: "woodblock"
+  canEmbed: true
   source: openhistoricalmap
   credit:
     id: 'make_a_donation'
@@ -32,6 +35,7 @@
   code: "J"
   layerId: "japanesescroll"
   nameId: "japanesescroll"
+  canEmbed: true
   source: openhistoricalmap
   credit:
     id: 'make_a_donation'

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -2,6 +2,7 @@
   code: "O"
   layerId: "historical"
   nameId: "historical"
+  source: openhistoricalmap
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -11,6 +12,7 @@
   code: "R"
   layerId: "railway"
   nameId: "railway"
+  source: openhistoricalmap
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -20,6 +22,7 @@
   code: "W"
   layerId: "woodblock"
   nameId: "woodblock"
+  source: openhistoricalmap
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -29,6 +32,7 @@
   code: "J"
   layerId: "japanesescroll"
   nameId: "japanesescroll"
+  source: openhistoricalmap
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'


### PR DESCRIPTION
Moved map label localization to the new spot for initializing a layer. The attribution code now decides whether to show OHM attribution based on layer configuration. Opted all the OHM-based layers back into allowing HTML embedding.

Fixes OpenHistoricalMap/issues#1175 and fixes OpenHistoricalMap/issues#1176 and fixes OpenHistoricalMap/issues#1174.