### PR TITLE
Add time slider to element pages

### DIFF
--- a/app/assets/javascripts/index/element.js
+++ b/app/assets/javascripts/index/element.js
@@ -49,6 +49,9 @@
         }
       });
 
+      if (!map.timeslider) {
+        addOpenHistoricalMapTimeSlider(map, hashParams);
+      }
       addOpenHistoricalMapInspector();
     };
 


### PR DESCRIPTION
When showing an element detail panel on the homepage, add a time slider control to the map if it isn’t already there.

Fixes OpenHistoricalMap/issues#1178.