### PR TITLE
Streamline time slider loading

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -284,24 +284,14 @@ $(function () {
     };
 
     page.load = function () {
-      // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-      // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-      function originalLoadFunction() {
-        const params = new URLSearchParams(location.search);
-        if (params.has("query")) {
-          $("#sidebar .search_form input[name=query]").value(params.get("query"));
-        }
-        return map.getState();
-      } // end originalLoadFunction
+      const params = new URLSearchParams(location.search);
+      if (params.has("query")) {
+        $("#sidebar .search_form input[name=query]").value(params.get("query"));
+      }
 
-      // "if map.timeslider" only try to add the timeslider if we don't already have it
-      if (map.timeslider) {
-        originalLoadFunction();
-      }
-      else {
-        const params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-        addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-      }
+      addOpenHistoricalMapTimeSlider(map);
+
+      return map.getState();
     };
 
     return page;

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -17,32 +17,21 @@ OSM.Changeset = function (map) {
   };
 
   page.load = function () {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      const changesetData = content.find("[data-changeset]").data("changeset");
-      changesetData.type = "changeset";
+    const changesetData = content.find("[data-changeset]").data("changeset");
+    changesetData.type = "changeset";
 
-      const hashParams = OSM.parseHash();
-      initialize();
-      map.addObject(changesetData, function (bounds) {
-        if (!hashParams.center && bounds.isValid()) {
-          OSM.router.withoutMoveListener(function () {
-            map.fitBounds(bounds);
-          });
-        }
-      })
-      $(".numbered_pagination").trigger("numbered_pagination:enable");
-    }// end originalLoadFunction
+    const hashParams = OSM.parseHash();
+    initialize();
+    map.addObject(changesetData, function (bounds) {
+      if (!hashParams.center && bounds.isValid()) {
+        OSM.router.withoutMoveListener(function () {
+          map.fitBounds(bounds);
+        });
+      }
+    });
+    $(".numbered_pagination").trigger("numbered_pagination:enable");
 
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      const params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    addOpenHistoricalMapTimeSlider(map);
   };
 
   function updateChangeset(method, url, include_data) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -244,23 +244,8 @@ OSM.Directions = function (map) {
     sidebarLoaded().then(enableListeners);
 
     map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
-  };
 
-  page.load = function() {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      page.pushstate();
-    }  // end originalLoadFunction
-
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    addOpenHistoricalMapTimeSlider(map);
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/element.js
+++ b/app/assets/javascripts/index/element.js
@@ -49,9 +49,7 @@
         }
       });
 
-      if (!map.timeslider) {
-        addOpenHistoricalMapTimeSlider(map, hashParams);
-      }
+      addOpenHistoricalMapTimeSlider(map);
       addOpenHistoricalMapInspector();
     };
 

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -64,40 +64,30 @@ OSM.Export = function (map) {
   };
 
   page.load = function () {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      map
-        .addLayer(locationFilter)
-        .on("moveend", update);
+    map
+      .addLayer(locationFilter)
+      .on("moveend", update);
 
-      $("#maxlat, #minlon, #maxlon, #minlat").change(boundsChanged);
-      $("#drag_box").click(enableFilter);
-      $(".export_form").on("submit", checkSubmit);
+    $("#maxlat, #minlon, #maxlon, #minlat").change(boundsChanged);
+    $("#drag_box").click(enableFilter);
+    $(".export_form").on("submit", checkSubmit);
 
-      document.querySelector(".export_form")
-        .addEventListener("turbo:submit-end", OSM.getTurboBlobHandler("map.osm"));
+    document.querySelector(".export_form")
+      .addEventListener("turbo:submit-end", OSM.getTurboBlobHandler("map.osm"));
 
-      document.querySelector(".export_form")
-        .addEventListener("turbo:before-fetch-response", OSM.turboHtmlResponseHandler);
+    document.querySelector(".export_form")
+      .addEventListener("turbo:before-fetch-response", OSM.turboHtmlResponseHandler);
 
-      document.querySelector(".export_form")
-        .addEventListener("turbo:before-fetch-request", function (event) {
-          event.detail.fetchOptions.headers.Accept = "application/xml";
-        });
+    document.querySelector(".export_form")
+      .addEventListener("turbo:before-fetch-request", function (event) {
+        event.detail.fetchOptions.headers.Accept = "application/xml";
+      });
 
-      update();
-      return map.getState();
-    } // end originalLoadFunction
+    update();
 
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    addOpenHistoricalMapTimeSlider(map);
+
+    return map.getState();
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -289,23 +289,12 @@ OSM.History = function (map) {
   };
 
   page.load = function () {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      map.addLayer(changesetsLayer);
-      map.on("moveend", moveEndListener);
-      map.on("zoomend", zoomEndListener);
-      loadFirstChangesets();
-    } // end originalLoadFunction
+    map.addLayer(changesetsLayer);
+    map.on("moveend", moveEndListener);
+    map.on("zoomend", zoomEndListener);
+    loadFirstChangesets();
 
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      var params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    addOpenHistoricalMapTimeSlider(map);
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -110,69 +110,58 @@ OSM.NewNote = function (map) {
   };
 
   page.load = function (path) {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      control.addClass("active");
+    control.addClass("active");
 
-      map.addLayer(noteLayer);
+    map.addLayer(noteLayer);
 
-      const params = new URLSearchParams(path.substring(path.indexOf("?")));
-      let markerLatlng;
+    const params = new URLSearchParams(path.substring(path.indexOf("?")));
+    let markerLatlng;
 
-      if (params.has("lat") && params.has("lon")) {
-        markerLatlng = L.latLng(params.get("lat"), params.get("lon"));
-      } else {
-        markerLatlng = map.getCenter();
-      }
-
-      map.panInside(markerLatlng, {
-        padding: [50, 50]
-      });
-
-      addNewNoteMarker(markerLatlng);
-
-      content.find("textarea")
-        .on("input", updateControls)
-        .attr("readonly", "readonly") // avoid virtual keyboard popping up on focus
-        .trigger("focus")
-        .removeAttr("readonly");
-
-      content.find("input[type=submit]").on("click", function (e) {
-        const location = newNoteMarker.getLatLng().wrap();
-        const text = content.find("textarea").val();
-
-        e.preventDefault();
-        $(this).prop("disabled", true);
-        newNoteMarker.options.draggable = false;
-        newNoteMarker.dragging.disable();
-
-        createNote(location, text, (feature) => {
-          if (typeof OSM.user === "undefined") {
-            const anonymousNotesCount = Number(Cookies.get("_osm_anonymous_notes_count")) || 0;
-            Cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { secure: true, expires: 30, path: "/", samesite: "lax" });
-          }
-          content.find("textarea").val("");
-          addCreatedNoteMarker(feature);
-          OSM.router.route("/note/" + feature.properties.id);
-        });
-      });
-
-      map.on("click", moveNewNoteMarkerToClick);
-      addNoteButton.on("disabled enabled", updateControls);
-      updateControls();
-
-      return map.getState();
-    } // end originalLoadFunction
-
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
+    if (params.has("lat") && params.has("lon")) {
+      markerLatlng = L.latLng(params.get("lat"), params.get("lon"));
+    } else {
+      markerLatlng = map.getCenter();
     }
-    else {
-      const params = querystring.parse(location.hash ? location.hash.substring(1) : location.search.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+
+    map.panInside(markerLatlng, {
+      padding: [50, 50]
+    });
+
+    addNewNoteMarker(markerLatlng);
+
+    content.find("textarea")
+      .on("input", updateControls)
+      .attr("readonly", "readonly") // avoid virtual keyboard popping up on focus
+      .trigger("focus")
+      .removeAttr("readonly");
+
+    content.find("input[type=submit]").on("click", function (e) {
+      const location = newNoteMarker.getLatLng().wrap();
+      const text = content.find("textarea").val();
+
+      e.preventDefault();
+      $(this).prop("disabled", true);
+      newNoteMarker.options.draggable = false;
+      newNoteMarker.dragging.disable();
+
+      createNote(location, text, (feature) => {
+        if (typeof OSM.user === "undefined") {
+          const anonymousNotesCount = Number(Cookies.get("_osm_anonymous_notes_count")) || 0;
+          Cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { secure: true, expires: 30, path: "/", samesite: "lax" });
+        }
+        content.find("textarea").val("");
+        addCreatedNoteMarker(feature);
+        OSM.router.route("/note/" + feature.properties.id);
+      });
+    });
+
+    map.on("click", moveNewNoteMarkerToClick);
+    addNoteButton.on("disabled enabled", updateControls);
+    updateControls();
+
+    addOpenHistoricalMapTimeSlider(map);
+
+    return map.getState();
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -12,19 +12,8 @@ OSM.Note = function (map) {
   };
 
   page.load = function (path, id) {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction(path, id) {
-      initialize(path, id);
-    }  // end originalLoadFunction
-
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    } else {
-      var params = querystring.parse(location.hash.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    initialize(path, id);
+    addOpenHistoricalMapTimeSlider(map);
   };
 
   function initialize(path, id, skipMoveToNote) {

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -444,29 +444,18 @@ OSM.Query = function (map) {
   };
 
   page.load = function (path, noCentre) {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction() {
-      const params = new URLSearchParams(path.substring(path.indexOf("?"))),
-        latlng = L.latLng(params.get("lat"), params.get("lon"));
+    const params = new URLSearchParams(path.substring(path.indexOf("?"))),
+          latlng = L.latLng(params.get("lat"), params.get("lon"));
 
-      if (!location.hash && !noCentre && !map.getBounds().contains(latlng)) {
-        OSM.router.withoutMoveListener(function () {
-          map.setView(latlng, 15);
-        });
-      }
-
-      queryOverpass([params.get("lat"), params.get("lon")]);
-    } // end originalLoadFunction
-
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
+    if (!location.hash && !noCentre && !map.getBounds().contains(latlng)) {
+      OSM.router.withoutMoveListener(function () {
+        map.setView(latlng, 15);
+      });
     }
-    else {
-      let params = querystring.parse(location.hash.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+
+    queryOverpass([params.get("lat"), params.get("lon")]);
+
+    addOpenHistoricalMapTimeSlider(map);
   };
 
   page.unload = function (sameController) {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -114,34 +114,23 @@ OSM.Search = function (map) {
   };
 
   page.load = function () {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      $(".search_results_entry[data-href]").each(function (index) {
-        const entry = $(this);
-        fetchReplace(this.dataset, entry.children().first())
-          .then(() => {
-            // go to first result of first geocoder
-            if (index === 0) {
-              const firstResult = entry.find("*[data-lat][data-lon]:first").first();
-              if (firstResult.length) {
-                panToSearchResult(firstResult.data());
-              }
+    $(".search_results_entry[data-href]").each(function (index) {
+      const entry = $(this);
+      fetchReplace(this.dataset, entry.children().first())
+        .then(() => {
+          // go to first result of first geocoder
+          if (index === 0) {
+            const firstResult = entry.find("*[data-lat][data-lon]:first").first();
+            if (firstResult.length) {
+              panToSearchResult(firstResult.data());
             }
-          });
-      });
+          }
+        });
+    });
 
-      return map.getState();
-    }  // end originalLoadFunction
+    addOpenHistoricalMapTimeSlider(map);
 
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      var params = querystring.parse(location.hash.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    return map.getState();
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -1,9 +1,11 @@
 /*
  * the wrapper function for adding the OpenHistoricalMap TimeSlider to the OHM map
- * called by the various OSM views to add this to their map, with optional callbacks
+ * called by the various OSM views to add this to their map
  */
 
-function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
+function addOpenHistoricalMapTimeSlider(map) {
+  if (map.timeslider) return;
+
   const historicalLayerKeys = ['historical', 'woodblock', 'japanesescroll', 'railway'];
 
   // Same options as the _osm_location cookie in index.js.
@@ -31,6 +33,7 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
     },
     position: 'bottomright',
   };
+  const params = OSM.parseHash();
   const date = (params && params.date) || Cookies.get('_ohm_timeslider_date');
   if (date && typeof date == 'string' && date.match(/^\-?\d{1,4}\-\d\d\-\d\d$/)) {
     sliderOptions.date = date;
@@ -43,8 +46,6 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
   // add the slider IF the OSM vector map is the layer showing
   if (getHistoryLayerIfShowing()) {
     addTimeSliderToMap(sliderOptions);
-  } else {
-    onreadycallback();
   }
 
   map.on('baselayerchange', function () {
@@ -85,16 +86,5 @@ function addOpenHistoricalMapTimeSlider (map, params, onreadycallback) {
     slideroptions.vectorLayer = ohmlayer;
 
     map.timeslider = new L.Control.OHMTimeSlider(slideroptions).addTo(map);
-
-    // if a callback was given for when the slider is ready, poll until it becomes ready
-    if (onreadycallback) {
-      var waitforslider = setInterval(() => {
-        var ready = ! getHistoryLayerIfShowing() || map.timeslider;
-        if (ready) {
-          clearInterval(waitforslider);
-          onreadycallback();
-        }
-      }, 0.1 * 1000);
-    }
   }
 }

--- a/app/assets/javascripts/index/timeslider.js
+++ b/app/assets/javascripts/index/timeslider.js
@@ -6,8 +6,6 @@
 function addOpenHistoricalMapTimeSlider(map) {
   if (map.timeslider) return;
 
-  const historicalLayerKeys = ['historical', 'woodblock', 'japanesescroll', 'railway'];
-
   // Same options as the _osm_location cookie in index.js.
   const expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);
@@ -76,7 +74,7 @@ function addOpenHistoricalMapTimeSlider(map) {
   function getHistoryLayerIfShowing () {
     let ohmlayer;
     map.eachLayer(function (layer) { // there's only 1 or 0 time layers at a time, so this works
-      if (historicalLayerKeys.indexOf(layer.options.layerId) !== -1) ohmlayer = layer;
+      if (layer instanceof L.OSM.OHM) ohmlayer = layer;
     });
     return ohmlayer;
   }


### PR DESCRIPTION
This PR restores normal page loading to be synchronous and loads the time slider synchronously as part of page loading. I’ve also fixed a bad merge in directions.js (which is currently inaccessible). The new streamlined initialization code only supports date parameters as hash parameters (after the `#`). I’ve removed support for date parameters as query parameters (after the `?`), which were only supported on a couple of the pages and are probably rarely used.

This also removes a hard-coded list of time-enabled layer IDs, so there are fewer steps to remember when adding a new layer.

Fixes OpenHistoricalMap/issues#1179.