### PR TITLE
1180 hundreds of ohm website test failures

### DIFF
--- a/.github/workflows/ohm-tests.yml
+++ b/.github/workflows/ohm-tests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['3.4']
+        ruby: ['3.2']
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
@@ -35,6 +35,8 @@ jobs:
       run: |
         sudo apt-get -yqq update
         sudo apt-get -yqq install memcached libvips-dev
+    - name: Install node modules
+      run: bundle exec bin/yarn install
     - name: Create database
       run: |
         sudo systemctl start postgresql
@@ -52,8 +54,6 @@ jobs:
         bundle exec rails db:migrate
         sed -f script/normalise-structure db/structure.sql > db/structure.actual
         diff -uw db/structure.expected db/structure.actual
-    - name: Install node modules
-      run: bundle exec bin/yarn install
     - name: Export javascript strings
       run: bundle exec i18n export
     - name: Compile assets

--- a/.github/workflows/ohm-tests.yml
+++ b/.github/workflows/ohm-tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 994-catchup+ci-configuration
+      - 1180-hundreds-of-ohm-website-test-failures
 #  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/test/controllers/messages/replies_controller_test.rb
+++ b/test/controllers/messages/replies_controller_test.rb
@@ -52,7 +52,7 @@ module Messages
       get new_message_reply_path(message)
       assert_response :success
       assert_template "new"
-      assert_select "title", "Re: #{message.title} | OpenStreetMap"
+      assert_select "title", "Re: #{message.title} | OpenHistoricalMap"
       assert_select "form[action='/messages']", :count => 1 do
         assert_select "input[type='hidden'][name='display_name'][value='#{recipient_user.display_name}']"
         assert_select "input#message_title[value='Re: #{message.title}']", :count => 1

--- a/test/factories/access_tokens.rb
+++ b/test/factories/access_tokens.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :access_token do
     user

--- a/test/factories/acls.rb
+++ b/test/factories/acls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :acl do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/changeset_comments.rb
+++ b/test/factories/changeset_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :changeset_comment do
     sequence(:body) { |n| "Changeset comment #{n}" }

--- a/test/factories/changeset_tags.rb
+++ b/test/factories/changeset_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :changeset_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/changesets.rb
+++ b/test/factories/changesets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :changeset do
     transient do

--- a/test/factories/diary_comments.rb
+++ b/test/factories/diary_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :diary_comment do
     sequence(:body) { |n| "This is diary comment #{n}" }

--- a/test/factories/diary_entries.rb
+++ b/test/factories/diary_entries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :diary_entry do
     sequence(:title) { |n| "Diary entry #{n}" }

--- a/test/factories/diary_entry_subscriptions.rb
+++ b/test/factories/diary_entry_subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :diary_entry_subscription
 end

--- a/test/factories/follows.rb
+++ b/test/factories/follows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :follow do
     follower :factory => :user

--- a/test/factories/issue_comment.rb
+++ b/test/factories/issue_comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :issue_comment do
     sequence(:body) { |n| "This is issue comment #{n}" }

--- a/test/factories/issues.rb
+++ b/test/factories/issues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :issue do
     # Default to reporting users

--- a/test/factories/languages.rb
+++ b/test/factories/languages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :language do
     code { "en" }

--- a/test/factories/messages.rb
+++ b/test/factories/messages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :message do
     sequence(:title) { |n| "Message #{n}" }

--- a/test/factories/node.rb
+++ b/test/factories/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :node do
     latitude { 1 * GeoRecord::SCALE }

--- a/test/factories/node_tags.rb
+++ b/test/factories/node_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :node_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/note_comments.rb
+++ b/test/factories/note_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :note_comment do
     sequence(:body) { |n| "This is note comment #{n}" }

--- a/test/factories/note_subscriptions.rb
+++ b/test/factories/note_subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :note_subscription
 end

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :note do
     latitude { 1 * GeoRecord::SCALE }

--- a/test/factories/oauth_access_grant.rb
+++ b/test/factories/oauth_access_grant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :oauth_access_grant, :class => "Doorkeeper::AccessGrant" do
     application :factory => :oauth_application

--- a/test/factories/oauth_access_token.rb
+++ b/test/factories/oauth_access_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :oauth_access_token, :class => "Doorkeeper::AccessToken" do
     application :factory => :oauth_application

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :oauth_application, :class => "Oauth2Application" do
     sequence(:name) { |n| "OAuth application #{n}" }

--- a/test/factories/old_node.rb
+++ b/test/factories/old_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_node do
     latitude { 1 * GeoRecord::SCALE }

--- a/test/factories/old_node_tags.rb
+++ b/test/factories/old_node_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_node_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/old_relation.rb
+++ b/test/factories/old_relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_relation do
     timestamp { Time.now.utc }

--- a/test/factories/old_relation_member.rb
+++ b/test/factories/old_relation_member.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_relation_member do
     sequence(:sequence_id)

--- a/test/factories/old_relation_tags.rb
+++ b/test/factories/old_relation_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_relation_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/old_way.rb
+++ b/test/factories/old_way.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_way do
     timestamp { Time.now.utc }

--- a/test/factories/old_way_node.rb
+++ b/test/factories/old_way_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_way_node do
     sequence_id { 1 }

--- a/test/factories/old_way_tags.rb
+++ b/test/factories/old_way_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :old_way_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/redaction.rb
+++ b/test/factories/redaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :redaction do
     sequence(:title) { |n| "Redaction #{n}" }

--- a/test/factories/relation.rb
+++ b/test/factories/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :relation do
     timestamp { Time.now.utc }

--- a/test/factories/relation_member.rb
+++ b/test/factories/relation_member.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :relation_member do
     sequence(:sequence_id)

--- a/test/factories/relation_tags.rb
+++ b/test/factories/relation_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :relation_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/reports.rb
+++ b/test/factories/reports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :report do
     sequence(:details) { |n| "Report details #{n}" }

--- a/test/factories/social_link.rb
+++ b/test/factories/social_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :social_link do
     sequence(:url) { |n| "https://test.com/#{n}" }

--- a/test/factories/tracepoints.rb
+++ b/test/factories/tracepoints.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tracepoint do
     trackid { 1 }

--- a/test/factories/traces.rb
+++ b/test/factories/traces.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :trace do
     sequence(:name) { |n| "Trace #{n}.gpx" }

--- a/test/factories/tracetags.rb
+++ b/test/factories/tracetags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tracetag do
     sequence(:tag) { |n| "Tag #{n}" }

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-pass_crypt = PasswordHash.create("test").first
+pass_crypt = PasswordHash.create("s3cr3t").first
 
 FactoryBot.define do
   factory :user do

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 pass_crypt = PasswordHash.create("test").first
 
 FactoryBot.define do

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-pass_crypt = PasswordHash.create("s3cr3t").first
+pass_crypt = PasswordHash.create("test").first
 
 FactoryBot.define do
   factory :user do

--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user_block do
     sequence(:reason) { |n| "User Block #{n}" }

--- a/test/factories/user_mute.rb
+++ b/test/factories/user_mute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user_mute do
     owner :factory => :user

--- a/test/factories/user_preferences.rb
+++ b/test/factories/user_preferences.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user_preference do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/factories/user_role.rb
+++ b/test/factories/user_role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user_role do
     user

--- a/test/factories/way.rb
+++ b/test/factories/way.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :way do
     timestamp { Time.now.utc }

--- a/test/factories/way_node.rb
+++ b/test/factories/way_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :way_node do
     sequence_id { 1 }

--- a/test/factories/way_tags.rb
+++ b/test/factories/way_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :way_tag do
     sequence(:k) { |n| "Key #{n}" }

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -55,9 +55,9 @@ class ApplicationHelperTest < ActionView::TestCase
     end
   end
 
-  def test_friendly_date
+  def test_friendly_date_ohm
     date = friendly_date(Time.utc(2014, 3, 5, 18, 58, 23))
-    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
+    assert_match %r{^<time title="March  5, 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
 
     date = friendly_date(Time.now.utc - 1.hour)
     assert_match %r{^<time title=".*">about 1 hour</time>$}, date
@@ -72,9 +72,9 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match %r{^<time title=".*">4 months</time>$}, date
   end
 
-  def test_friendly_date_ago
+  def test_friendly_date_ago_ohm
     date = friendly_date_ago(Time.utc(2014, 3, 5, 18, 58, 23))
-    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
+    assert_match %r{^<time title="March  5, 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
 
     date = friendly_date_ago(Time.now.utc - 1.hour)
     assert_match %r{^<time title=".*">about 1 hour ago</time>$}, date

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -30,25 +30,25 @@ class IssuesHelperTest < ActionView::TestCase
     end
   end
 
-  def test_reportable_heading_note
+  def test_reportable_heading_note_ohm
     note = create(:note, :created_at => "2020-03-14", :updated_at => "2021-05-16")
 
     heading = reportable_heading note
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "Note ##{note.id} created on 14 March 2020 at 00:00, updated on 16 May 2021 at 00:00"
+    assert_dom dom_heading, ":root", "Note ##{note.id} created on March 14, 2020 at 00:00, updated on 16 May 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", note_url(note)
     end
   end
 
-  def test_reportable_heading_user
+  def test_reportable_heading_user_ohm
     user = create(:user, :display_name => "Someone", :created_at => "2020-07-18")
 
     heading = reportable_heading user
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "User Someone created on 18 July 2020 at 00:00"
+    assert_dom dom_heading, ":root", "User Someone created on July 18, 2020 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", user_url(user)
     end

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -11,7 +11,7 @@ class IssuesHelperTest < ActionView::TestCase
     heading = reportable_heading diary_comment
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on 15 March 2020 at 00:00, updated on 17 May 2021 at 00:00"
+    assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on 15 March 2020 at 00:00, updated on May 17, 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry, :anchor => "comment#{diary_comment.id}")
     end
@@ -36,7 +36,7 @@ class IssuesHelperTest < ActionView::TestCase
     heading = reportable_heading note
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "Note ##{note.id} created on March 14, 2020 at 00:00, updated on 16 May 2021 at 00:00"
+    assert_dom dom_heading, ":root", "Note ##{note.id} created on March 14, 2020 at 00:00, updated on May 16, 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", note_url(note)
     end

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -11,20 +11,20 @@ class IssuesHelperTest < ActionView::TestCase
     heading = reportable_heading diary_comment
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on 15 March 2020 at 00:00, updated on May 17, 2021 at 00:00"
+    assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on March 15, 2020 at 00:00, updated on May 17, 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry, :anchor => "comment#{diary_comment.id}")
     end
   end
 
-  def test_reportable_heading_diary_entry
+  def test_reportable_heading_diary_entry_ohm
     create(:language, :code => "en")
     diary_entry = create(:diary_entry, :title => "Important Subject", :created_at => "2020-03-24", :updated_at => "2021-05-26")
 
     heading = reportable_heading diary_entry
 
     dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
-    assert_dom dom_heading, ":root", "Diary Entry Important Subject created on 24 March 2020 at 00:00, updated on 26 May 2021 at 00:00"
+    assert_dom dom_heading, ":root", "Diary Entry Important Subject created on March 24, 2020 at 00:00, updated on May 26, 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry)
     end

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -4,7 +4,7 @@ class NoteHelperTest < ActionView::TestCase
   include ERB::Util
   include ApplicationHelper
 
-  def test_note_event
+  def test_note_event_ohm
     date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
@@ -12,7 +12,7 @@ class NoteHelperTest < ActionView::TestCase
     assert_dom note_event_dom, ":root", :text => /^Created by anonymous .* ago$/ do
       assert_dom "> a", :count => 0
       assert_dom "> time", :count => 1 do
-        assert_dom "> @title", "5 March 2014 at 21:37"
+        assert_dom "> @title", "March  5, 2014 at 21:37"
         assert_dom "> @datetime", "2014-03-05T21:37:45Z"
       end
     end
@@ -23,7 +23,7 @@ class NoteHelperTest < ActionView::TestCase
         assert_dom "> @href", "/user/#{ERB::Util.u(user.display_name)}"
       end
       assert_dom "> time", :count => 1 do
-        assert_dom "> @title", "5 March 2014 at 21:37"
+        assert_dom "> @title", "March  5, 2014 at 21:37"
         assert_dom "> @datetime", "2014-03-05T21:37:45Z"
       end
     end

--- a/test/integration/changeset_bbox_test.rb
+++ b/test/integration/changeset_bbox_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ChangesetBboxTest < ActionDispatch::IntegrationTest

--- a/test/integration/changeset_upload_download_test.rb
+++ b/test/integration/changeset_upload_download_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ChangesetUploadDownloadTest < ActionDispatch::IntegrationTest

--- a/test/integration/compressed_requests_test.rb
+++ b/test/integration/compressed_requests_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CompressedRequestsTest < ActionDispatch::IntegrationTest

--- a/test/integration/cors_test.rb
+++ b/test/integration/cors_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CORSTest < ActionDispatch::IntegrationTest

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class LoginTest < ActionDispatch::IntegrationTest
@@ -23,7 +25,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -34,7 +36,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.email, "test"
+    try_password_login uppercase_user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -45,7 +47,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -55,7 +57,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password
     user = create(:user)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -64,7 +66,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_upcase
     user = create(:user)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -73,7 +75,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_titlecase
     user = create(:user)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -82,7 +84,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -91,7 +93,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -100,7 +102,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_titlecase
     user = create(:user, :pending)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -109,36 +111,36 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
   def test_login_email_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
   def test_login_email_password_suspended_titlecase
     user = create(:user, :suspended)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -146,7 +148,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -156,7 +158,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -166,7 +168,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -180,7 +182,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -191,7 +193,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.display_name, "test"
+    try_password_login uppercase_user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -202,7 +204,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -212,7 +214,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password
     user = create(:user)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -221,7 +223,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_upcase
     user = create(:user)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -230,7 +232,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_downcase
     user = create(:user)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -239,7 +241,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -248,7 +250,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -257,7 +259,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_downcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -266,36 +268,36 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
   def test_login_username_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
   def test_login_username_password_suspended_downcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -303,7 +305,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -313,7 +315,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -323,7 +325,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -332,7 +334,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_remember_me
     user = create(:user)
 
-    try_password_login user.email, "test", "yes"
+    try_password_login user.email, "s3cr3t", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -342,7 +344,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_remember_me
     user = create(:user)
 
-    try_password_login user.display_name, "test", "yes"
+    try_password_login user.display_name, "s3cr3t", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -410,7 +412,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -584,7 +586,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -727,7 +729,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -866,7 +868,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -1005,7 +1007,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 
@@ -1144,7 +1146,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
     assert_select "span.username", false
     assert_select "div.alert.alert-danger", /your account has been suspended/ do
-      assert_select "a[href='mailto:openstreetmap@example.com']", "support"
+      assert_select "a[href='mailto:dev@openhistoricalmap.org']", "support"
     end
   end
 

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -25,7 +25,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email, "s3cr3t"
+    try_password_login user.email, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -36,7 +36,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.email, "s3cr3t"
+    try_password_login uppercase_user.email, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -47,7 +47,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email.titlecase, "s3cr3t"
+    try_password_login user.email.titlecase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -57,7 +57,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password
     user = create(:user)
 
-    try_password_login user.email, "s3cr3t"
+    try_password_login user.email, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -66,7 +66,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_upcase
     user = create(:user)
 
-    try_password_login user.email.upcase, "s3cr3t"
+    try_password_login user.email.upcase, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -75,7 +75,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_titlecase
     user = create(:user)
 
-    try_password_login user.email.titlecase, "s3cr3t"
+    try_password_login user.email.titlecase, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -84,7 +84,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.email, "s3cr3t"
+    try_password_login user.email, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -93,7 +93,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.email.upcase, "s3cr3t"
+    try_password_login user.email.upcase, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -102,7 +102,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_titlecase
     user = create(:user, :pending)
 
-    try_password_login user.email.titlecase, "s3cr3t"
+    try_password_login user.email.titlecase, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -111,7 +111,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.email, "s3cr3t"
+    try_password_login user.email, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -123,7 +123,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.email.upcase, "s3cr3t"
+    try_password_login user.email.upcase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -135,7 +135,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended_titlecase
     user = create(:user, :suspended)
 
-    try_password_login user.email.titlecase, "s3cr3t"
+    try_password_login user.email.titlecase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -148,7 +148,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email, "s3cr3t"
+    try_password_login user.email, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -158,7 +158,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.upcase, "s3cr3t"
+    try_password_login user.email.upcase, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -168,7 +168,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.titlecase, "s3cr3t"
+    try_password_login user.email.titlecase, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -182,7 +182,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name, "s3cr3t"
+    try_password_login user.display_name, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -193,7 +193,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.display_name, "s3cr3t"
+    try_password_login uppercase_user.display_name, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -204,7 +204,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name.downcase, "s3cr3t"
+    try_password_login user.display_name.downcase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -214,7 +214,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password
     user = create(:user)
 
-    try_password_login user.display_name, "s3cr3t"
+    try_password_login user.display_name, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -223,7 +223,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_upcase
     user = create(:user)
 
-    try_password_login user.display_name.upcase, "s3cr3t"
+    try_password_login user.display_name.upcase, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -232,7 +232,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_downcase
     user = create(:user)
 
-    try_password_login user.display_name.downcase, "s3cr3t"
+    try_password_login user.display_name.downcase, "test"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -241,7 +241,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.display_name, "s3cr3t"
+    try_password_login user.display_name, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -250,7 +250,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.upcase, "s3cr3t"
+    try_password_login user.display_name.upcase, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -259,7 +259,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_downcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.downcase, "s3cr3t"
+    try_password_login user.display_name.downcase, "test"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -268,7 +268,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.display_name, "s3cr3t"
+    try_password_login user.display_name, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -280,7 +280,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.upcase, "s3cr3t"
+    try_password_login user.display_name.upcase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -292,7 +292,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended_downcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.downcase, "s3cr3t"
+    try_password_login user.display_name.downcase, "test"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -305,7 +305,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.upcase, "s3cr3t"
+    try_password_login user.display_name.upcase, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -315,7 +315,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name, "s3cr3t"
+    try_password_login user.display_name, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -325,7 +325,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.downcase, "s3cr3t"
+    try_password_login user.display_name.downcase, "test"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -334,7 +334,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_remember_me
     user = create(:user)
 
-    try_password_login user.email, "s3cr3t", "yes"
+    try_password_login user.email, "test", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -344,7 +344,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_remember_me
     user = create(:user)
 
-    try_password_login user.display_name, "s3cr3t", "yes"
+    try_password_login user.display_name, "test", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name

--- a/test/integration/node_versions_test.rb
+++ b/test/integration/node_versions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NodeVersionsTest < ActionDispatch::IntegrationTest

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "jwt"
 

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class PageLocaleTest < ActionDispatch::IntegrationTest

--- a/test/integration/redirect_test.rb
+++ b/test/integration/redirect_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RedirectTest < ActionDispatch::IntegrationTest

--- a/test/integration/relation_versions_test.rb
+++ b/test/integration/relation_versions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RelationVersionsTest < ActionDispatch::IntegrationTest

--- a/test/integration/short_links_test.rb
+++ b/test/integration/short_links_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ShortLinksTest < ActionDispatch::IntegrationTest

--- a/test/integration/user_blocks_test.rb
+++ b/test/integration/user_blocks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserBlocksTest < ActionDispatch::IntegrationTest

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserCreationTest < ActionDispatch::IntegrationTest

--- a/test/integration/user_diaries_test.rb
+++ b/test/integration/user_diaries_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserDiariesTest < ActionDispatch::IntegrationTest

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserTermsSeenTest < ActionDispatch::IntegrationTest

--- a/test/integration/way_versions_test.rb
+++ b/test/integration/way_versions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class WayVersionsTest < ActionDispatch::IntegrationTest

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -155,13 +155,13 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal "text", message.body_format
   end
 
-  def test_from_mail_prefix
+  def test_from_mail_prefix_ohm
     sender_user = create(:user)
     recipient_user = create(:user)
     mail = Mail.new do
       from "from@example.com"
       to "to@example.com"
-      subject "[OpenHistoricalMap] Test message"
+      subject "Test message"
       date Time.now.utc
       content_type "text/plain; charset=utf-8"
       body "This is a test & a message"

--- a/test/system/account_deletion_test.rb
+++ b/test/system/account_deletion_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class AccountDeletionTest < ApplicationSystemTestCase

--- a/test/system/account_home_test.rb
+++ b/test/system/account_home_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class AccountHomeTest < ApplicationSystemTestCase

--- a/test/system/account_pd_declaration_test.rb
+++ b/test/system/account_pd_declaration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class AccountPdDeclarationTest < ApplicationSystemTestCase

--- a/test/system/account_rename_test.rb
+++ b/test/system/account_rename_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class AccountRenameTest < ApplicationSystemTestCase

--- a/test/system/account_terms_test.rb
+++ b/test/system/account_terms_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class AccountTermsTest < ApplicationSystemTestCase

--- a/test/system/browse_comment_links_test.rb
+++ b/test/system/browse_comment_links_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class BrowseCommentLinksTest < ApplicationSystemTestCase

--- a/test/system/changeset_comments_test.rb
+++ b/test/system/changeset_comments_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ChangesetCommentsTest < ApplicationSystemTestCase

--- a/test/system/changeset_elements_test.rb
+++ b/test/system/changeset_elements_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ChangesetElementsTest < ApplicationSystemTestCase

--- a/test/system/changeset_test.rb
+++ b/test/system/changeset_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ChangesetSystemTest < ApplicationSystemTestCase

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class CreateNoteTest < ApplicationSystemTestCase

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class DashboardSystemTest < ApplicationSystemTestCase

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class DiaryEntrySystemTest < ApplicationSystemTestCase

--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class DirectionsSystemTest < ApplicationSystemTestCase

--- a/test/system/element_current_version_test.rb
+++ b/test/system/element_current_version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ElementCurrentVersionTest < ApplicationSystemTestCase

--- a/test/system/element_history_test.rb
+++ b/test/system/element_history_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ElementHistoryTest < ApplicationSystemTestCase

--- a/test/system/element_old_version_test.rb
+++ b/test/system/element_old_version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ElementOldVersionTest < ApplicationSystemTestCase

--- a/test/system/embed_test.rb
+++ b/test/system/embed_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class EmbedTest < ApplicationSystemTestCase

--- a/test/system/fixthemap_test.rb
+++ b/test/system/fixthemap_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class FixthemapTest < ApplicationSystemTestCase

--- a/test/system/follows_test.rb
+++ b/test/system/follows_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class FollowsTest < ApplicationSystemTestCase

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class HistoryTest < ApplicationSystemTestCase

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class IndexTest < ApplicationSystemTestCase

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class IssuesTest < ApplicationSystemTestCase

--- a/test/system/messages_test.rb
+++ b/test/system/messages_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class MessagesTest < ApplicationSystemTestCase

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class NoteCommentsTest < ApplicationSystemTestCase

--- a/test/system/note_layer_test.rb
+++ b/test/system/note_layer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class NoteLayerTest < ApplicationSystemTestCase

--- a/test/system/oauth2_test.rb
+++ b/test/system/oauth2_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class Oauth2Test < ApplicationSystemTestCase

--- a/test/system/preferences_test.rb
+++ b/test/system/preferences_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class PreferencesTest < ApplicationSystemTestCase

--- a/test/system/profile_company_change_test.rb
+++ b/test/system/profile_company_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ProfileCompanyChangeTest < ApplicationSystemTestCase

--- a/test/system/profile_description_change_test.rb
+++ b/test/system/profile_description_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ProfileLinksChangeTest < ApplicationSystemTestCase

--- a/test/system/profile_image_change_test.rb
+++ b/test/system/profile_image_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ProfileImageChangeTest < ApplicationSystemTestCase

--- a/test/system/profile_links_change_test.rb
+++ b/test/system/profile_links_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ProfileLinksChangeTest < ApplicationSystemTestCase

--- a/test/system/profile_location_change_test.rb
+++ b/test/system/profile_location_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ProfileLocationChangeTest < ApplicationSystemTestCase

--- a/test/system/query_features_test.rb
+++ b/test/system/query_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class QueryFeaturesSystemTest < ApplicationSystemTestCase

--- a/test/system/redaction_destroy_test.rb
+++ b/test/system/redaction_destroy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class RedactionDestroyTest < ApplicationSystemTestCase

--- a/test/system/report_diary_comment_test.rb
+++ b/test/system/report_diary_comment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ReportDiaryCommentTest < ApplicationSystemTestCase

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ReportDiaryEntryTest < ApplicationSystemTestCase

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ReportNoteTest < ApplicationSystemTestCase

--- a/test/system/report_user_test.rb
+++ b/test/system/report_user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ReportUserTest < ApplicationSystemTestCase

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ResolveNoteTest < ApplicationSystemTestCase

--- a/test/system/rich_text_test.rb
+++ b/test/system/rich_text_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class RichTextSystemTest < ApplicationSystemTestCase

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class SearchTest < ApplicationSystemTestCase

--- a/test/system/select_language_test.rb
+++ b/test/system/select_language_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class SelectLanguageTest < ApplicationSystemTestCase

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class SiteTest < ApplicationSystemTestCase

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserBlocksSystemTest < ApplicationSystemTestCase

--- a/test/system/user_email_change_test.rb
+++ b/test/system/user_email_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserEmailChangeTest < ApplicationSystemTestCase

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserLoginTest < ApplicationSystemTestCase

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserLogoutTest < ApplicationSystemTestCase

--- a/test/system/user_muting_test.rb
+++ b/test/system/user_muting_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserMutingTest < ApplicationSystemTestCase

--- a/test/system/user_notes_test.rb
+++ b/test/system/user_notes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserNotesTest < ApplicationSystemTestCase

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserSignupTest < ApplicationSystemTestCase

--- a/test/system/user_status_change_test.rb
+++ b/test/system/user_status_change_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserStatusChangeTest < ApplicationSystemTestCase

--- a/test/system/user_suspension_test.rb
+++ b/test/system/user_suspension_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UserSuspensionTest < ApplicationSystemTestCase

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class UsersTest < ApplicationSystemTestCase

--- a/test/system/view_communities_test.rb
+++ b/test/system/view_communities_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class ViewCommunitiesTest < ApplicationSystemTestCase


### PR DESCRIPTION
It's a large number of files but the vast majority simply prepend 

```
# frozen_string_literal: true
```

to test suites. These are found via diffs against upstream and would be incorporated in the next upstream catchup anyway. Pulling them in now eases the chore of cleaning up tests in https://github.com/OpenHistoricalMap/issues/issues/1180 by making divergences clear.

Tests have been modified to use our date format and our support email address.

The GitHub action was resequenced so that `yarn install` comes a little earlier.

Test failures have been reduced from 137 to 116. This code change needs to go in as a benchmark against the next Translatewiki update.


