### PR TITLE
Replace OpenStreetMap with OpenHistoricalMap in meta tags

### DIFF
--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -22,8 +22,8 @@
 <% if Settings.key?(:publisher_url) -%>
   <%= tag.link :rel => "publisher", :href => Settings.publisher_url %>
 <% end -%>
-<%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
-<%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
+<%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenHistoricalMap Search", :href => asset_path("osm.xml") %>
+<%= tag.meta :name => "description", :content => "OpenHistoricalMap is the free wiki world map." %>
 <%= opengraph_tags(@title, @opengraph_properties || {}) %>
 <% if flash[:matomo_goal] -%>
   <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>


### PR DESCRIPTION
Replaced hard-coded references to OpenStreetMap with OpenHistoricalMap in the common meta tags on most pages.

Fixes OpenHistoricalMap/issues#1214.