### PR TITLE
Whitespace changes to en translations; fix to rake task; frozen_string_literal to tests

### DIFF
--- a/.github/workflows/ohm-tests.yml
+++ b/.github/workflows/ohm-tests.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       RAILS_ENV: test
       OPENSTREETMAP_MEMCACHE_SERVERS: 127.0.0.1
+      PGGSSENCMODE: disable # attempt to solve "PG::Error: Unexpected binary struct layout "
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2484,26 +2484,21 @@ en:
         join_the_community:
           title: Join the community
           explanation_html: |
-            If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
-            proceed is to join the OpenHistoricalMap community and add or repair the data yourself.
+            If you have noticed a problem with our map data, for example a road is missing or your address, the best way to proceed is to join the OpenHistoricalMap community and add or repair the data yourself.
         add_a_note:
           instructions_1_html: |
-            Just click %{note_icon} or the same icon on the map display.
-            This will add a marker to the map, which you can move
-            by dragging. Add your message, then click save, and other mappers will investigate.
+            Just click %{note_icon} or the same icon on the map display. This will add a marker to the map, which you can move by dragging. Add your message, then click save, and other mappers will investigate.
       other_concerns:
         title: Other concerns
         concerns_ohm_html: |
-          If you have concerns about how our data is being used or about the contents please consult our
-          %{copyright_link} for more legal information, or %{contact_link}.
+          If you have concerns about how our data is being used or about the contents please consult our %{copyright_link} for more legal information, or %{contact_link}.
         copyright: copyright page
         contact: contact us
         contact_url: https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Communication
     help:
       title: Getting Help
       introduction: |
-        OpenHistoricalMap has several resources for learning about the project, asking and answering questions,
-        and collaboratively discussing and documenting mapping topics.
+        OpenHistoricalMap has several resources for learning about the project, asking and answering questions, and collaboratively discussing and documenting mapping topics.
       welcome:
         url: /welcome
         title: Welcome to OpenHistoricalMap
@@ -2568,8 +2563,7 @@ en:
     any_questions:
       title: Any questions?
       paragraph_1_html: |
-        OpenHistoricalMap has several resources for learning about the project, asking and answering
-        questions, and collaboratively discussing and documenting mapping topics. %{help_link}.
+        OpenHistoricalMap has several resources for learning about the project, asking and answering questions, and collaboratively discussing and documenting mapping topics. %{help_link}.
       get_help_here: Get help here
       welcome_mat: Check out the Welcome Mat
       welcome_mat_url: https://welcome.openstreetmap.org/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2425,9 +2425,7 @@ en:
           accepts any liability.
         infringement_title_html: Copyright infringement
         infringement_1_html: |
-          OHM contributors are reminded never to add data from any
-          copyrighted sources (e.g. Google Maps or printed maps) without
-          explicit permission from the copyright holders.
+          OHM contributors are reminded never to add data from any copyrighted sources (e.g. Google Maps or printed maps) without explicit permission from the copyright holders.
         infringement_2_ohm_html: |
           If you believe that copyrighted material has been inappropriately
           added to the OpenHistoricalMap database or this site, please %{contact_team_link}.
@@ -2590,20 +2588,16 @@ en:
     welcome:
       title: Welcome!
       introduction: |
-        Welcome to OpenHistoricalMap, the free and editable map of world history. Now that you're signed
-        up, you're all set to get started mapping. Here's a quick guide with the most important
-        things you need to know.
+        Welcome to OpenHistoricalMap, the free and editable map of world history. Now that you're signed up, you're all set to get started mapping. Here's a quick guide with the most important things you need to know.
       whats_on_the_map:
         title: What's on the Map
         on_the_map_ohm_html: |
           OpenHistoricalMap tracks changes to natural and human geography throughout the world.
-          We have millions of entries from %{past_and_present}, from empires and glaciers to houses and restaurants.
-          You can map whatever real-world features are interesting to you.
+          We have millions of entries from %{past_and_present}, from empires and glaciers to houses and restaurants. You can map whatever real-world features are interesting to you.
         past_and_present: both the past and present
         off_the_map_html: |
           OpenHistoricalMap %{doesnt} include fictional alternative histories,
-          known errors from antique maps, and data from copyrighted sources. Unless you have special
-          permission, don't copy from modern maps of the past that you find online or in print.
+          known errors from antique maps, and data from copyrighted sources. Unless you have special permission, don't copy from modern maps of the past that you find online or in print.
         doesnt: doesn't
       basic_terms:
         title: Basic Terms For Mapping
@@ -2633,8 +2627,7 @@ en:
     add_a_note:
       title: No Time To Edit? Add a Note!
       para_1: |
-        If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
-        easy to add a note.
+        If you just want something small fixed and don't have the time to sign up and learn how to edit, it's easy to add a note.
       para_2_html: |
         Just click %{note_icon} or the same icon on %{map_link}.
         This will add a marker to the map, which you can move by dragging.
@@ -2645,8 +2638,7 @@ en:
       lede_text: |
         People from all over the world contribute to or use OpenHistoricalMap.
         While many participate as individuals, others have formed communities.
-        These groups come in a range of sizes and represent geographies from small towns to large multi-country regions.
-        They can also be formal or informal.
+        These groups come in a range of sizes and represent geographies from small towns to large multi-country regions. They can also be formal or informal.
       local_chapters:
         title: Local Chapters
         about_text: |

--- a/lib/tasks/ohm_vs_osm_rb.rake
+++ b/lib/tasks/ohm_vs_osm_rb.rake
@@ -45,10 +45,7 @@ namespace :ohm do
             v.scan(/\bOHM\b/i).count,
             v.scan(/\bOSM\b/i).count
           ]
-          if (counts.any? { |n| n != 0 }) then
-            tally[@locale].store(new_path.join("."), counts)
-          end
-          # new_path.join(".")
+          tally[@locale].store(new_path.join("."), counts) if (@locale == 'en' || counts.any? { |n| n != 0 })
         else
           raise "wtf? #{ v }"
         end

--- a/test/controllers/accounts/pd_declarations_controller_test.rb
+++ b/test/controllers/accounts/pd_declarations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module Accounts

--- a/test/controllers/accounts/terms_controller_test.rb
+++ b/test/controllers/accounts/terms_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module Accounts

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class AccountsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/changeset_subscriptions_controller_test.rb
+++ b/test/controllers/changeset_subscriptions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ChangesetSubscriptionsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ChangesetsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ConfirmationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class DashboardsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/directions_controller_test.rb
+++ b/test/controllers/directions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class DirectionsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ErrorsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/export_controller_test.rb
+++ b/test/controllers/export_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ExportControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/feature_queries_controller_test.rb
+++ b/test/controllers/feature_queries_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class BrowseControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/follows_controller_test.rb
+++ b/test/controllers/follows_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class FollowsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/issue_comments_controller_test.rb
+++ b/test/controllers/issue_comments_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class IssueCommentsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class IssuesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/layers_panes_controller_test.rb
+++ b/test/controllers/layers_panes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class LayersPanesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/legend_panes_controller_test.rb
+++ b/test/controllers/legend_panes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class LegendPanesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module Api

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NodesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NotesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/oauth2_applications_controller_test.rb
+++ b/test/controllers/oauth2_applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/oauth2_authorizations_controller_test.rb
+++ b/test/controllers/oauth2_authorizations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/oauth2_authorized_applications_controller_test.rb
+++ b/test/controllers/oauth2_authorized_applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class OldNodesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/old_relation_members_controller_test.rb
+++ b/test/controllers/old_relation_members_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class OldRelationMembersControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class OldRelationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class OldWaysControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class PasswordsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RedactionsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/relation_members_controller_test.rb
+++ b/test/controllers/relation_members_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RelationMembersControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/relations_controller_test.rb
+++ b/test/controllers/relations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RelationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ReportsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SearchesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/share_panes_controller_test.rb
+++ b/test/controllers/share_panes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SharePanesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SiteControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TracesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "user_blocks/table_test_helper"
 

--- a/test/controllers/user_mutes_controller_test.rb
+++ b/test/controllers/user_mutes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserMutesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserRolesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/ways_controller_test.rb
+++ b/test/controllers/ways_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class WaysControllerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This PR is not as big of a deal as it seems. It

- removes whitespace from some `en` translations, making it easier to read by translators when it appears in a translatewiki textarea
- fixes a bug in my [rake task](https://github.com/OpenHistoricalMap/issues/issues/1200)
- adds "# frozen_string_literal: true" to controller tests; these would eventually be picked up in an upstream merge but adding them now aids in diffing files against upstream as I continue to [reduce the number of test failures and errors](https://github.com/OpenHistoricalMap/issues/issues/1180)
