### PR TITLE
Ensure consistent passwords during testing

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -42,24 +42,24 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
 
-    get login_path, :params => { :username => user.display_name, :password => "test" }
+    get login_path, :params => { :username => user.display_name, :password => "s3cr3t" }
     assert_response :success
     assert_template "sessions/new"
 
-    post login_path, :params => { :username => user.display_name, :password => "test" }
+    post login_path, :params => { :username => user.display_name, :password => "s3cr3t" }
     assert_redirected_to root_path
 
-    post login_path, :params => { :username => " #{user.display_name}", :password => "test" }
+    post login_path, :params => { :username => " #{user.display_name}", :password => "s3cr3t" }
     assert_redirected_to root_path
 
-    post login_path, :params => { :username => "#{user.display_name} ", :password => "test" }
+    post login_path, :params => { :username => "#{user.display_name} ", :password => "s3cr3t" }
     assert_redirected_to root_path
   end
 
   def test_login_remembered
     user = create(:user)
 
-    post login_path, :params => { :username => user.display_name, :password => "test", :remember_me => "yes" }
+    post login_path, :params => { :username => user.display_name, :password => "s3cr3t", :remember_me => "yes" }
     assert_redirected_to root_path
 
     assert_equal 28 * 86400, session[:_remember_for]
@@ -68,7 +68,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   def test_login_not_remembered
     user = create(:user)
 
-    post login_path, :params => { :username => user.display_name, :password => "test", :remember_me => "0" }
+    post login_path, :params => { :username => user.display_name, :password => "s3cr3t", :remember_me => "0" }
     assert_redirected_to root_path
 
     assert_nil session[:_remember_for]

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-pass_crypt = PasswordHash.create("test").first
+pass_crypt = PasswordHash.create("s3cr3t").first
 
 FactoryBot.define do
   factory :user do

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -25,7 +25,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -36,7 +36,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.email, "test"
+    try_password_login uppercase_user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -47,7 +47,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -57,7 +57,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password
     user = create(:user)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -66,7 +66,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_upcase
     user = create(:user)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -75,7 +75,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_titlecase
     user = create(:user)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -84,7 +84,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -93,7 +93,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -102,7 +102,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_pending_titlecase
     user = create(:user, :pending)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -111,7 +111,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -123,7 +123,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -135,7 +135,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_suspended_titlecase
     user = create(:user, :suspended)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -148,7 +148,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email, "test"
+    try_password_login user.email, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -158,7 +158,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.upcase, "test"
+    try_password_login user.email.upcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -168,7 +168,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.email.titlecase, "test"
+    try_password_login user.email.titlecase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -182,7 +182,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -193,7 +193,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login uppercase_user.display_name, "test"
+    try_password_login uppercase_user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", uppercase_user.display_name
@@ -204,7 +204,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     _uppercase_user = build(:user, :display_name => user.display_name.upcase).tap { |u| u.save(:validate => false) }
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -214,7 +214,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password
     user = create(:user)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -223,7 +223,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_upcase
     user = create(:user)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -232,7 +232,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_downcase
     user = create(:user)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -241,7 +241,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending
     user = create(:user, :pending)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -250,7 +250,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_upcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -259,7 +259,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_pending_downcase
     user = create(:user, :pending)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "confirm"
     assert_select "span.username", false
@@ -268,7 +268,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended
     user = create(:user, :suspended)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -280,7 +280,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended_upcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -292,7 +292,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_suspended_downcase
     user = create(:user, :suspended)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "sessions/new"
     assert_select "span.username", false
@@ -305,7 +305,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.upcase, "test"
+    try_password_login user.display_name.upcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -315,7 +315,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name, "test"
+    try_password_login user.display_name, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -325,7 +325,7 @@ class LoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create(:user_block, :needs_view, :user => user)
 
-    try_password_login user.display_name.downcase, "test"
+    try_password_login user.display_name.downcase, "s3cr3t"
 
     assert_template "user_blocks/show"
     assert_select "span.username", user.display_name
@@ -334,7 +334,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_email_password_remember_me
     user = create(:user)
 
-    try_password_login user.email, "test", "yes"
+    try_password_login user.email, "s3cr3t", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name
@@ -344,7 +344,7 @@ class LoginTest < ActionDispatch::IntegrationTest
   def test_login_username_password_remember_me
     user = create(:user)
 
-    try_password_login user.display_name, "test", "yes"
+    try_password_login user.display_name, "s3cr3t", "yes"
 
     assert_template "changesets/history"
     assert_select "span.username", user.display_name

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -161,7 +161,7 @@ class OAuth2Test < ActionDispatch::IntegrationTest
     get oauth_authorization_path(options)
     assert_redirected_to login_path(:referer => request.fullpath)
 
-    post login_path(:username => user.email, :password => "test")
+    post login_path(:username => user.email, :password => "s3cr3t")
     follow_redirect!
     assert_response :success
 

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -9,7 +9,7 @@ class PageLocaleTest < ActionDispatch::IntegrationTest
 
       get "/login"
       follow_redirect!
-      post "/login", :params => { :username => user.email, :password => "test" }
+      post "/login", :params => { :username => user.email, :password => "s3cr3t" }
       follow_redirect!
 
       get "/diary/new"
@@ -34,7 +34,7 @@ class PageLocaleTest < ActionDispatch::IntegrationTest
 
       get "/login"
       follow_redirect!
-      post "/login", :params => { :username => user.email, :password => "test" }
+      post "/login", :params => { :username => user.email, :password => "s3cr3t" }
       follow_redirect!
 
       get "/diary"

--- a/test/integration/user_blocks_test.rb
+++ b/test/integration/user_blocks_test.rb
@@ -43,7 +43,7 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     follow_redirect!
     assert_response :success
-    post "/login", :params => { "username" => moderator.email, "password" => "test", :referer => "/user_blocks/#{block.id}/edit" }
+    post "/login", :params => { "username" => moderator.email, "password" => "s3cr3t", :referer => "/user_blocks/#{block.id}/edit" }
     assert_response :redirect
     follow_redirect!
     assert_response :success

--- a/test/integration/user_diaries_test.rb
+++ b/test/integration/user_diaries_test.rb
@@ -15,7 +15,7 @@ class UserDiariesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     # We can now login
-    post "/login", :params => { "username" => user.email, "password" => "test", :referer => "/diary/new" }
+    post "/login", :params => { "username" => user.email, "password" => "s3cr3t", :referer => "/diary/new" }
     assert_response :redirect
     follow_redirect!
     assert_response :success

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -25,7 +25,7 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    post "/login", :params => { :username => user.email, :password => "test", :referer => "/diary/new" }
+    post "/login", :params => { :username => user.email, :password => "s3cr3t", :referer => "/diary/new" }
     # but now we need to look at the terms
     assert_redirected_to account_terms_path(:referer => "/diary/new")
     follow_redirect!
@@ -49,7 +49,7 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    post "/login", :params => { :username => user.email, :password => "test", :referer => "/diary/new" }
+    post "/login", :params => { :username => user.email, :password => "s3cr3t", :referer => "/diary/new" }
     # but now we need to look at the terms
     assert_redirected_to account_terms_path(:referer => "/diary/new")
 

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -17,7 +17,7 @@ class UserLoginTest < ApplicationSystemTestCase
     end
 
     fill_in "username", :with => user2.email
-    fill_in "password", :with => "test"
+    fill_in "password", :with => "s3cr3t"
     click_on "Log in"
 
     assert_button "Second User"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -208,7 +208,7 @@ module ActiveSupport
 
     def session_for(user)
       get login_path
-      post login_path, :params => { :username => user.display_name, :password => "test" }
+      post login_path, :params => { :username => user.display_name, :password => "s3cr3t" }
       follow_redirect!
     end
 


### PR DESCRIPTION
I noticed that in the [latest commit](https://github.com/OpenHistoricalMap/ohm-website/commit/5ebdaa6e3dd5f1ac0b8f28c714c56e9091556f4c) (as of these lines), a change was introduced as follows:

```diff
-      fill_in "password", :with => "test"
+      fill_in "password", :with => "s3cr3t"
```

Upstream at OSM, this was introduced at https://github.com/openstreetmap/openstreetmap-website/pull/6431, as a means to work around a strange behaviour in Selenium. If changed in one place, it probably should change in all places to ensure consistency.

I quickly checked and this seems to help me when running tests locally:

```
staging:
2659 runs, 1106716 assertions, 104 failures, 54 errors, 0 skips

after these changes:
2659 runs, 1107275 assertions, 30 failures, 7 errors, 0 skips
```