### PR TITLE
fix danger method

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -15,7 +15,7 @@ modified_yml_files = git.modified_files.select do |file|
 end
 
 # Report if some translation file (except en.yml) is modified
-if modified_yml_files.empty? or branch_for_head == 'translatewiki'
+if modified_yml_files.empty? or github.branch_for_head == 'translatewiki'
   auto_label.remove("inappropriate-translations")
 else
   modified_files_str = modified_yml_files.map { |file| "`#{file}`" }.join(", ")


### PR DESCRIPTION
Danger has been erroring out on translatewiki PRs. Attempting to stop tagging legitimate PRs as "inappropriate-translations", hopefully this fixes the issue.