### PR TITLE
Fix enclosing features query when date slider is active

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -394,13 +394,11 @@ OSM.Query = function (map) {
     }
 
     // Build queries - match original format when no dateFilter
-    const enclosed = dateFilter ? `(pivot.a)${dateFilter}` : "(pivot.a);out tags bb",
+    const enclosed = `(pivot.a)${dateFilter};out tags bb`,
       nearby = dateFilter
         ? `(node${here}${dateFilter};way${here}${dateFilter};);out tags ${geom};relation${here}${dateFilter};out ${geom};`
         : `(node${here};way${here};);out tags ${geom};relation${here};out ${geom};`,
-      isin = dateFilter
-        ? `is_in(${latlng})->.a;way${enclosed};out geom;relation${enclosed};out geom;`
-        : `is_in(${latlng})->.a;way${enclosed};out ids ${geom};relation${enclosed};`;
+      isin = `is_in(${latlng})->.a;way${enclosed};out ids ${geom};relation${enclosed};`;
 
     $("#sidebar_content .query-intro")
       .hide();


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/1364
When the time slider is active, clicking on a point that falls inside an **area mapped as a `way`** (a park, a building, a landuse polygon) breaks the "Enclosing features" section with:

> Cannot destructure property 'maxlon' of 'undefined' as it is undefined.

Clicking on points enclosed only by `relation`s (administrative boundaries, timezones, etc.) works fine — which is why the bug seemed intermittent.
