### PR TITLE
Fixes https://github.com/OpenHistoricalMap/issues/issues/1365

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ gem "logstasher"
 # Used to generate images for traces
 gem "bzip2-ffi"
 gem "ffi-libarchive"
-gem "gd2-ffij", ">= 0.4.0"
+gem "gd2-ffij", :github => "rkoeze/gd2-ffij", :ref => "a203a8d5ef004a4198950e86329228fe3f331d06"
 gem "marcel"
 
 # Used for S3 object storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
     active_record_union (1.3.0)
       activerecord (>= 6.0)
 
+GIT
+  remote: https://github.com/rkoeze/gd2-ffij.git
+  revision: a203a8d5ef004a4198950e86329228fe3f331d06
+  ref: a203a8d5ef004a4198950e86329228fe3f331d06
+  specs:
+    gd2-ffij (0.4.1.dev)
+      ffi (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -296,8 +304,6 @@ GEM
     frozen_record (0.27.4)
       activemodel
     fspath (3.1.2)
-    gd2-ffij (0.4.0)
-      ffi (>= 1.0.0)
     git (1.19.1)
       addressable (~> 2.8)
       rchardet (~> 1.8)
@@ -777,7 +783,7 @@ DEPENDENCIES
   faraday
   ffi-libarchive
   frozen_record
-  gd2-ffij (>= 0.4.0)
+  gd2-ffij!
   htmlentities
   http_accept_language (~> 2.1.1)
   i18n-js (~> 4.2.3)


### PR DESCRIPTION
Modifies `Gemfile` and `Gemfile.lock` in order to use a version of the `gd2-ffij` gem that doesn't cause errors in the ohm-website test suite.
