### PR TITLE
Fix layer minimaps in the Map Layers sidebar

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,8 +7,9 @@
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
 Rails.application.configure do
-  connect_src = [:self, "*.openhistoricalmap.org", "openhistoricalmap.github.io", "*.amazonaws.com"]
-  img_src = [:self, :data, "www.gravatar.com", "*.wp.com", "tile.openstreetmap.org", "gps.tile.openstreetmap.org", "api.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr"]
+  tile_src = ["tile.openstreetmap.org", "gps.tile.openstreetmap.org", "api.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr"]
+  connect_src = [:self, "*.openhistoricalmap.org", "openhistoricalmap.github.io", "*.amazonaws.com", *tile_src]
+  img_src = [:self, :data, "www.gravatar.com", "*.wp.com", *tile_src]
   script_src = [:self, "openhistoricalmap.github.io"]
   style_src = [:self, "openhistoricalmap.github.io"]
   worker_src = [:self, :blob, "0.0.0.0:3000"]

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -5,7 +5,7 @@
   canEmbed: true
   source: openhistoricalmap
   isVectorStyle: true
-  styleUrl: "https://openhistoricalmap.org/map-styles/historical/historical.json"
+  styleUrl: "/map-styles/historical/historical.json"
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -18,7 +18,7 @@
   canEmbed: true
   source: openhistoricalmap
   isVectorStyle: true
-  styleUrl: "https://openhistoricalmap.org/map-styles/railway/railway.json"
+  styleUrl: "/map-styles/railway/railway.json"
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -31,7 +31,7 @@
   canEmbed: true
   source: openhistoricalmap
   isVectorStyle: true
-  styleUrl: "https://openhistoricalmap.org/map-styles/woodblock/woodblock.json"
+  styleUrl: "/map-styles/woodblock/woodblock.json"
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'
@@ -44,7 +44,7 @@
   canEmbed: true
   source: openhistoricalmap
   isVectorStyle: true
-  styleUrl: "https://openhistoricalmap.org/map-styles/japanese_scroll/japanese_scroll.json"
+  styleUrl: "/map-styles/japanese_scroll/japanese_scroll.json"
   credit:
     id: 'make_a_donation'
     href: 'https://openstreetmap.app.neoncrm.com/forms/ohm'


### PR DESCRIPTION
- The OHM layers loaded their style from an absolute URL, which broke with CORS across environments. They now use a relative URL, so the style loads from the same origin as the page (preview, staging, or production).

- The minimaps render with maplibre, which fetches tiles via fetch(). The tile hosts were only allowed in img-src, so CSP blocked them in connect-src. Added the tile hosts to connect-src as well.

Ref: https://github.com/OpenHistoricalMap/issues/issues/1378

cc. @erictheise 