### PR TITLE
Move the time slider to a Nominatim search result's date

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -9,6 +9,7 @@
 //= require leaflet.share
 //= require leaflet.query
 //= require index/contextmenu
+//= require index/date_utils
 //= require index/search
 //= require index/layers/data
 //= require index/export

--- a/app/assets/javascripts/index/date_utils.js
+++ b/app/assets/javascripts/index/date_utils.js
@@ -1,0 +1,60 @@
+// Shared date helpers for the map UI, kept in one place so query.js and
+// search.js do not each carry their own copy.
+OSM.Date = {
+  // Compare ISO 8601 dates correctly (handles BCE dates where string comparison fails)
+  compareDates: function (date1, date2) {
+    if (!date1 && !date2) return 0;
+    if (!date1) return -1;
+    if (!date2) return 1;
+
+    const match1 = date1.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
+    const match2 = date2.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
+    if (!match1 || !match2) return date1.localeCompare(date2);
+
+    const [, year1Str, month1Str, day1Str] = match1;
+    const [, year2Str, month2Str, day2Str] = match2;
+    const year1Int = parseInt(year1Str, 10);
+    const year2Int = parseInt(year2Str, 10);
+
+    if (year1Int !== year2Int) return year1Int - year2Int;
+
+    const month1 = month1Str ? parseInt(month1Str, 10) : 1;
+    const month2 = month2Str ? parseInt(month2Str, 10) : 1;
+    if (month1 !== month2) return month1 - month2;
+
+    const day1 = day1Str ? parseInt(day1Str, 10) : 1;
+    const day2 = day2Str ? parseInt(day2Str, 10) : 1;
+    return day1 - day2;
+  },
+
+  // Days in a month, accounting for leap years (BCE has no year 0).
+  daysInMonth: function (year, month) {
+    if (month !== 2) return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+    const y = year > 0 ? year : year + 1;
+    const leap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
+    return leap ? 29 : 28;
+  },
+
+  // Fill a partial date to a full YYYY-MM-DD, at the start or end of its period.
+  padDate: function (value, startend) {
+    if (value === null || value === undefined || value === "") return null;
+    const date = String(value).trim().replace(/^\+/, "");
+    if (/^-?\d+-\d\d-\d\d$/.test(date)) return date;
+    const yearMonth = date.match(/^(-?\d+)-(\d\d)$/);
+    if (yearMonth) {
+      if (startend === "start") return `${date}-01`;
+      const lastDay = OSM.Date.daysInMonth(parseInt(yearMonth[1], 10), parseInt(yearMonth[2], 10));
+      return `${date}-${String(lastDay).padStart(2, "0")}`;
+    }
+    if (/^-?\d+$/.test(date)) return startend === "start" ? `${date}-01-01` : `${date}-12-31`;
+    return null;
+  },
+
+  // True when a feature with these dates exists at the given time. The end date
+  // pads to the last day of its period, so a feature ending in 1700 lasts all year.
+  existsAt: function (startDate, endDate, atDate) {
+    const afterStart = !startDate || OSM.Date.compareDates(OSM.Date.padDate(startDate, "start"), atDate) <= 0;
+    const beforeEnd = !endDate || OSM.Date.compareDates(OSM.Date.padDate(endDate, "end"), atDate) > 0;
+    return afterStart && beforeEnd;
+  }
+};

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -320,41 +320,11 @@ OSM.Query = function (map) {
     return match ? parseInt(match[1], 10) < 1000 : false;
   }
 
-  // Compare ISO 8601 dates correctly (handles BCE dates where string comparison fails)
-  function compareDates(date1, date2) {
-    if (!date1 && !date2) return 0;
-    if (!date1) return -1;
-    if (!date2) return 1;
-
-    const match1 = date1.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
-    const match2 = date2.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
-    if (!match1 || !match2) return date1.localeCompare(date2);
-
-    const [, year1Str, month1Str, day1Str] = match1;
-    const [, year2Str, month2Str, day2Str] = match2;
-    const year1Int = parseInt(year1Str, 10);
-    const year2Int = parseInt(year2Str, 10);
-
-    if (year1Int !== year2Int) return year1Int - year2Int;
-
-    const month1 = month1Str ? parseInt(month1Str, 10) : 1;
-    const month2 = month2Str ? parseInt(month2Str, 10) : 1;
-    if (month1 !== month2) return month1 - month2;
-
-    const day1 = day1Str ? parseInt(day1Str, 10) : 1;
-    const day2 = day2Str ? parseInt(day2Str, 10) : 1;
-    return day1 - day2;
-  }
-
   function filterByDate(elements, currentDate) {
     if (!currentDate) return elements;
     return elements.filter(element => {
       const tags = element.tags || {};
-      const startDate = tags.start_date;
-      const endDate = tags.end_date;
-      if (startDate && compareDates(startDate, currentDate) > 0) return false;
-      if (endDate && compareDates(endDate, currentDate) <= 0) return false;
-      return true;
+      return OSM.Date.existsAt(tags.start_date, tags.end_date, currentDate);
     });
   }
 

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -91,48 +91,17 @@ OSM.Search = function (map) {
     }
   }
 
-  // Compare two ISO 8601 dates, tolerating partial (year, year-month) and BCE values.
-  // Same logic as compareDates() in query.js; kept local until we share a date util.
-  function compareDates(date1, date2) {
-    const match1 = date1.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
-    const match2 = date2.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
-    if (!match1 || !match2) return date1.localeCompare(date2);
-
-    const [, year1, month1, day1] = match1;
-    const [, year2, month2, day2] = match2;
-    if (parseInt(year1, 10) !== parseInt(year2, 10)) return parseInt(year1, 10) - parseInt(year2, 10);
-
-    const m1 = month1 ? parseInt(month1, 10) : 1;
-    const m2 = month2 ? parseInt(month2, 10) : 1;
-    if (m1 !== m2) return m1 - m2;
-
-    return (day1 ? parseInt(day1, 10) : 1) - (day2 ? parseInt(day2, 10) : 1);
-  }
-
-  // The slider only accepts full YYYY-MM-DD, so pad a year or year-month before setDate().
-  function padDate(value) {
-    if (value === null || value === undefined || value === "") return null;
-    const parts = String(value).trim().match(/^(-?\d{1,4})(?:-(\d{2}))?(?:-(\d{2}))?/);
-    if (!parts) return null;
-    return `${parts[1]}-${parts[2] || "01"}-${parts[3] || "01"}`;
-  }
-
   // Move the slider so the picked feature is visible. If it already exists at the
   // current time we leave the slider alone.
   function adjustTimeSliderToResult(data) {
     if (!map.timeslider) return;
+    if (!data.startDate && !data.endDate) return;
 
-    const startDate = data.startDate != null && data.startDate !== "" ? String(data.startDate) : null;
-    const endDate = data.endDate != null && data.endDate !== "" ? String(data.endDate) : null;
-    if (!startDate && !endDate) return;
-
-    const current = map.timeslider.getDate();
-    const afterStart = !startDate || compareDates(startDate, current) <= 0;
-    const beforeEnd = !endDate || compareDates(endDate, current) > 0;
-    if (afterStart && beforeEnd) return; // already visible now
+    // leave the slider alone if the feature already exists at the current time
+    if (OSM.Date.existsAt(data.startDate, data.endDate, map.timeslider.getDate())) return;
 
     // out of view: jump to start_date, or to end_date when there is no start
-    const target = padDate(startDate || endDate);
+    const target = OSM.Date.padDate(data.startDate || data.endDate, "start");
     if (target) map.timeslider.setDate(target);
   }
 

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -131,34 +131,23 @@ OSM.Search = function (map) {
   };
 
   page.load = function () {
-    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
-    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
-    function originalLoadFunction () {
-      $(".search_results_entry[data-href]").each(function (index) {
-        const entry = $(this);
-        fetchReplace(this.dataset, entry.children().first())
-          .then(() => {
-            // go to first result of first geocoder
-            if (index === 0) {
-              const firstResult = entry.find("*[data-lat][data-lon]:first").first();
-              if (firstResult.length) {
-                panToSearchResult(firstResult.data());
-              }
+    $(".search_results_entry[data-href]").each(function (index) {
+      const entry = $(this);
+      fetchReplace(this.dataset, entry.children().first())
+        .then(() => {
+          // go to first result of first geocoder
+          if (index === 0) {
+            const firstResult = entry.find("*[data-lat][data-lon]:first").first();
+            if (firstResult.length) {
+              panToSearchResult(firstResult.data());
             }
-          });
-      });
+          }
+        });
+    });
 
-      return map.getState();
-    }  // end originalLoadFunction
+    addOpenHistoricalMapTimeSlider(map);
 
-    // "if map.timeslider" only try to add the timeslider if we don't already have it
-    if (map.timeslider) {
-      originalLoadFunction();
-    }
-    else {
-      var params = querystring.parse(location.hash.substring(1));
-      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
-    }
+    return map.getState();
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -91,10 +91,56 @@ OSM.Search = function (map) {
     }
   }
 
+  // Compare two ISO 8601 dates, tolerating partial (year, year-month) and BCE values.
+  // Same logic as compareDates() in query.js; kept local until we share a date util.
+  function compareDates(date1, date2) {
+    const match1 = date1.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
+    const match2 = date2.match(/^(-?\d+)(?:-(\d{1,2}))?(?:-(\d{1,2}))?/);
+    if (!match1 || !match2) return date1.localeCompare(date2);
+
+    const [, year1, month1, day1] = match1;
+    const [, year2, month2, day2] = match2;
+    if (parseInt(year1, 10) !== parseInt(year2, 10)) return parseInt(year1, 10) - parseInt(year2, 10);
+
+    const m1 = month1 ? parseInt(month1, 10) : 1;
+    const m2 = month2 ? parseInt(month2, 10) : 1;
+    if (m1 !== m2) return m1 - m2;
+
+    return (day1 ? parseInt(day1, 10) : 1) - (day2 ? parseInt(day2, 10) : 1);
+  }
+
+  // The slider only accepts full YYYY-MM-DD, so pad a year or year-month before setDate().
+  function padDate(value) {
+    if (value === null || value === undefined || value === "") return null;
+    const parts = String(value).trim().match(/^(-?\d{1,4})(?:-(\d{2}))?(?:-(\d{2}))?/);
+    if (!parts) return null;
+    return `${parts[1]}-${parts[2] || "01"}-${parts[3] || "01"}`;
+  }
+
+  // Move the slider so the picked feature is visible. If it already exists at the
+  // current time we leave the slider alone.
+  function adjustTimeSliderToResult(data) {
+    if (!map.timeslider) return;
+
+    const startDate = data.startDate != null && data.startDate !== "" ? String(data.startDate) : null;
+    const endDate = data.endDate != null && data.endDate !== "" ? String(data.endDate) : null;
+    if (!startDate && !endDate) return;
+
+    const current = map.timeslider.getDate();
+    const afterStart = !startDate || compareDates(startDate, current) <= 0;
+    const beforeEnd = !endDate || compareDates(endDate, current) > 0;
+    if (afterStart && beforeEnd) return; // already visible now
+
+    // out of view: jump to start_date, or to end_date when there is no start
+    const target = padDate(startDate || endDate);
+    if (target) map.timeslider.setDate(target);
+  }
+
   function clickSearchResult(e) {
     const data = $(this).data();
 
     panToSearchResult(data);
+    adjustTimeSliderToResult(data);
 
     // Let clicks to object browser links propagate.
     if (data.type && data.id) return;
@@ -116,23 +162,34 @@ OSM.Search = function (map) {
   };
 
   page.load = function () {
-    $(".search_results_entry[data-href]").each(function (index) {
-      const entry = $(this);
-      fetchReplace(this.dataset, entry.children().first())
-        .then(() => {
-          // go to first result of first geocoder
-          if (index === 0) {
-            const firstResult = entry.find("*[data-lat][data-lon]:first").first();
-            if (firstResult.length) {
-              panToSearchResult(firstResult.data());
+    // the original page.load content is the function below, and is used when one visits this page, be it first load OR later routing change
+    // below, we wrap "if map.timeslider" so we only try to add the timeslider if we don't already have it
+    function originalLoadFunction () {
+      $(".search_results_entry[data-href]").each(function (index) {
+        const entry = $(this);
+        fetchReplace(this.dataset, entry.children().first())
+          .then(() => {
+            // go to first result of first geocoder
+            if (index === 0) {
+              const firstResult = entry.find("*[data-lat][data-lon]:first").first();
+              if (firstResult.length) {
+                panToSearchResult(firstResult.data());
+              }
             }
-          }
-        });
-    });
+          });
+      });
 
-    addOpenHistoricalMapTimeSlider(map);
+      return map.getState();
+    }  // end originalLoadFunction
 
-    return map.getState();
+    // "if map.timeslider" only try to add the timeslider if we don't already have it
+    if (map.timeslider) {
+      originalLoadFunction();
+    }
+    else {
+      var params = querystring.parse(location.hash.substring(1));
+      addOpenHistoricalMapTimeSlider(map, params, originalLoadFunction);
+    }
   };
 
   page.unload = function () {

--- a/app/controllers/searches/nominatim_queries_controller.rb
+++ b/app/controllers/searches/nominatim_queries_controller.rb
@@ -74,6 +74,7 @@ module Searches
                       :min_lat => min_lat, :max_lat => max_lat,
                       :min_lon => min_lon, :max_lon => max_lon,
                       :prefix => prefix, :name => name, :suffix => suffix,
+                      :start_date => start_date, :end_date => end_date,
                       :type => object_type, :id => object_id)
       end
     rescue StandardError => e


### PR DESCRIPTION
Search results now move the time slider to the feature's period, not just the place.

- Nominatim results include `start_date`/`end_date`.
- Clicking a result jumps the slider to `start_date` (or `end_date`) when the feature isn't visible at the current time; otherwise it stays put.
- Shared date helpers in one `OSM.Date` util (no more duplicated `compareDates`).
- Fixed partial `end_date`: a feature ending in 1700 now lasts all of 1700.

Ref: https://github.com/OpenHistoricalMap/issues/issues/196