### PR TITLE
Fix dev container CI by returning server_protocol to upstream value

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 # The server protocol and host
-server_protocol: "https"
-server_url: "www.openhistoricalmap.org"
+server_protocol: "http"
+server_url: "openstreetmap.example.com"
 embed_server_url: "https://embed.openhistoricalmap.org/"
 
 # Publisher

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -152,7 +152,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
     register_email = ActionMailer::Base.deliveries.first
     assert_equal register_email.to.first, new_email
-    found_confirmation_url = register_email.parts.first.parts.first.to_s =~ %r{\shttps://test.host(/\S+)\s}
+    found_confirmation_url = register_email.parts.first.parts.first.to_s =~ %r{\shttp://test.host(/\S+)\s}
     assert found_confirmation_url
     confirmation_url = Regexp.last_match(1)
 

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -339,7 +339,7 @@ describe("OSM", function () {
     it("creates a location cookie value", function () {
       $("body").append("<div id='map'>");
       const map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
-      map.updateLayers("");
+      map.updateLayers("M");
       expect(OSM.locationCookie(map)).to.eq("-3.685|57.625|9|M");
       $("#map").remove();
     });
@@ -347,7 +347,7 @@ describe("OSM", function () {
     it("respects zoomPrecision", function () {
       $("body").append("<div id='map'>");
       const map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
-      map.updateLayers("");
+      map.updateLayers("M");
       expect(OSM.locationCookie(map)).to.eq("-3.685|57.625|9|M");
       // map.setZoom() doesn't update the zoom level for some reason
       // using map._zoom here to update the zoom level manually

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -242,7 +242,7 @@ class RichTextTest < ActiveSupport::TestCase
       r = RichText.new("text", "foo repl.example.com/some/path?query=te<st&limit=20>10#result12 bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "repl.example.com/some/path?query=te<st&limit=20>10#result12" do
-          assert_dom "> @href", "https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12"
+          assert_dom "> @href", "http://replace-me.example.com/some/path?query=te<st&limit=20>10#result12"
           assert_dom "> @rel", "nofollow noopener noreferrer"
         end
       end
@@ -326,7 +326,7 @@ class RichTextTest < ActiveSupport::TestCase
       r = RichText.new("text", "foo wiki.example.com/Tag:surface%3Dmetal bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "wiki.example.com/Tag:surface%3Dmetal" do
-          assert_dom "> @href", "https://replace-me-wiki.example.com/Tag:surface%3Dmetal"
+          assert_dom "> @href", "http://replace-me-wiki.example.com/Tag:surface%3Dmetal"
           assert_dom "> @rel", "nofollow noopener noreferrer"
         end
       end
@@ -351,8 +351,8 @@ class RichTextTest < ActiveSupport::TestCase
     with_settings(:linkify => { :detection_rules => [{ :patterns => ["@(?<username>\\w+)"], :path_template => "user/\\k<username>" }] }) do
       r = RichText.new("text", "foo @example bar")
       assert_html r do
-        assert_dom "a", :count => 1, :text => "https://test.host/user/example" do
-          assert_dom "> @href", "https://test.host/user/example"
+        assert_dom "a", :count => 1, :text => "http://test.host/user/example" do
+          assert_dom "> @href", "http://test.host/user/example"
           assert_dom "> @rel", "nofollow noopener noreferrer"
         end
       end


### PR DESCRIPTION
 Fixes OpenHistoricalMap/issues#1407
Fixes OpenHistoricalMap/issues#1180

The dev container CI was failing because `settings.yml` had server_protocol=https (introduced in https://github.com/OpenHistoricalMap/ohm-website/commit/234f27207542c42181e69e84839241139a2c41c0). With that value the app tries to work with Secure cookies, which does not work for tests.

I have also fixed the teaspoon locationCookie tests by using the Mapnik layer. This is the same change as in #439, but I had to include it here too to make sure all tests pass.