### PR TITLE
Add translator documentation for all en.yml strings

### DIFF
--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -21,231 +21,3942 @@ qqq:
       * ltr: for left-to-right scripts (unnecessary, as it is inherited from English)
   date:
     formats:
-      brief: '{{Optional|Only translate if the date format for a year must include
-        a prefix or suffix.}}'
-      range: '{{Optional|Only translate if the format for a date range uses different
-        punctuation or spacing.}}'
+      brief: "{{Optional|Only translate if the date format for a year must include a prefix or suffix.}}"
+      brief_bce: Date format for years in the BCE era (Before Common Era). %{year} is replaced with the numeric year. Used in browse/history views for historical map features.
+      brief_ce: Date format for years in the CE era (Common Era) when disambiguation from BCE is needed. %{year} is replaced with the numeric year. Used alongside brief_bce.
+      heatmap: 'Date format used as a tooltip label on individual cells of the contribution calendar heatmap on user profile pages. Uses strftime codes: %B = full month name, %-d = day without leading zero.'
+      range: "{{Optional|Only translate if the format for a date range uses different punctuation or spacing.}}"
+  time:
+    formats:
+      friendly: 'Full date-and-time format used in tooltip titles on relative timestamps throughout the site (e.g. ''3 hours ago''). Uses strftime codes: %B = month name, %e = day, %Y = year, %H:%M = 24-hour time.'
+      blog: 'Date-only format used in blog/diary-style contexts. Uses strftime codes: %B = month name, %e = day, %Y = year.'
+  count:
+    at_least_pattern: Badge label shown when a count exceeds a threshold and is capped (e.g. '500+'). %{count} is the threshold number. Used on the users list page and issues page.
   helpers:
+    file:
+      prompt: Placeholder text shown on a file input field before a file is chosen. Used on the GPS trace upload form.
     submit:
       diary_comment:
-        create: '{{identical|Save}}'
+        create: "{{identical|Save}}"
       diary_entry:
-        create: '{{identical|Publish}}'
-        update: '{{identical|Update}}'
+        create: "{{identical|Publish}}"
+        update: "{{identical|Update}}"
+      issue_comment:
+        create: Submit button label on the issue comment form.
+      message:
+        create: Submit button label on the compose message form.
+      oauth2_application:
+        create: Submit button label on the new OAuth2 application registration form.
+        update: Submit button label on the edit OAuth2 application form.
+      redaction:
+        create: Submit button label on the new redaction form.
+        update: Submit button label on the edit redaction form.
       trace:
-        create: '{{identical|Upload}}'
+        create: "{{identical|Upload}}"
+        update: Submit button label on the edit GPS trace form.
+      user_block:
+        create: Submit button label on the new user block form.
+        update: Submit button label on the edit user block form.
   activerecord:
+    errors:
+      messages:
+        display_name_is_user_n: Validation error shown when a user tries to set their display name to 'user_N' where N is not their own user ID. Shown in account settings.
+      models:
+        user_mute:
+          attributes:
+            subject:
+              format: Wrapper format for validation error messages on the muted user field. %{message} is the specific error text.
+          is_already_muted: Validation error shown when trying to mute a user who is already muted.
+        social_link:
+          attributes:
+            url:
+              http_parse_error: Validation error shown when a social profile link URL does not start with http:// or https://.
     models:
-      country: '{{identical|Country}}'
+      acl: Name of the ACL (Access Control List) model, used in error messages.
+      changeset: Name of the Changeset model, used in error messages.
+      changeset_tag: Name of the Changeset Tag model, used in error messages.
+      country: "{{identical|Country}}"
+      diary_comment: Name of the Diary Comment model, used in error messages.
+      diary_entry: Name of the Diary Entry model, used in error messages.
+      friend: Name of the Friend model, used in error messages.
+      issue: Name of the Issue model, used in error messages.
+      language: Name of the Language model, used in error messages.
+      message: Name of the Message model, used in error messages.
+      node: Name of the Node model (a point on the map), used in error messages.
+      node_tag: Name of the Node Tag model, used in error messages.
+      note: Name of the Note model (a map note), used in error messages.
+      old_node: Name of the Old Node model (historical version of a node), used in error messages.
+      old_node_tag: Name of the Old Node Tag model, used in error messages.
+      old_relation: Name of the Old Relation model (historical version of a relation), used in error messages.
+      old_relation_member: Name of the Old Relation Member model, used in error messages.
+      old_relation_tag: Name of the Old Relation Tag model, used in error messages.
+      old_way: Name of the Old Way model (historical version of a way), used in error messages.
+      old_way_node: Name of the Old Way Node model, used in error messages.
+      old_way_tag: Name of the Old Way Tag model, used in error messages.
+      relation: Name of the Relation model (a grouping of map elements), used in error messages.
+      relation_member: Name of the Relation Member model, used in error messages.
+      relation_tag: Name of the Relation Tag model, used in error messages.
+      report: Name of the Report model, used in error messages.
+      session: Name of the Session model, used in error messages.
+      trace: Name of the Trace model (a GPS trace), used in error messages.
+      tracepoint: Name of the Trace Point model, used in error messages.
+      tracetag: Name of the Trace Tag model, used in error messages.
+      user: Name of the User model, used in error messages.
+      user_preference: Name of the User Preference model, used in error messages.
+      user_token: Name of the User Token model, used in error messages.
+      way: Name of the Way model (a line or area on the map), used in error messages.
+      way_node: Name of the Way Node model, used in error messages.
+      way_tag: Name of the Way Tag model, used in error messages.
     attributes:
+      client_application:
+        name: Label for the application name field in OAuth client application forms.
+        url: Label for the main application URL field in OAuth client application forms.
+        callback_url: Label for the callback URL field in OAuth client application forms.
+        support_url: Label for the support URL field in OAuth client application forms.
+        allow_read_prefs: Label for the read user preferences permission checkbox in OAuth client application forms.
+        allow_write_prefs: Label for the modify user preferences permission checkbox in OAuth client application forms.
+        allow_write_diary: Label for the create diary entries permission checkbox in OAuth client application forms.
+        allow_write_api: Label for the modify the map permission checkbox in OAuth client application forms.
+        allow_write_changeset_comments: Label for the comment on changesets permission checkbox in OAuth client application forms.
+        allow_read_gpx: Label for the read private GPS traces permission checkbox in OAuth client application forms.
+        allow_write_gpx: Label for the upload GPS traces permission checkbox in OAuth client application forms.
+        allow_write_notes: Label for the modify notes permission checkbox in OAuth client application forms.
+      diary_comment:
+        body: Label for the body field of a diary comment in error messages.
+      diary_entry:
+        user: Label for the user field of a diary entry in error messages.
+        title: Label for the title/subject field of a diary entry in error messages.
+        body: Label for the body field of a diary entry in error messages.
+        latitude: Label for the latitude field of a diary entry in error messages.
+        longitude: Label for the longitude field of a diary entry in error messages.
+        language_code: Label for the language field of a diary entry in error messages.
+      doorkeeper/application:
+        name: Label for the application name field in Doorkeeper OAuth application forms.
+        redirect_uri: Label for the redirect URIs field in Doorkeeper OAuth application forms.
+        confidential: Label for the confidential application checkbox in Doorkeeper OAuth application forms.
+        scopes: Label for the permissions/scopes field in Doorkeeper OAuth application forms.
+      friend:
+        user: Label for the user field of a friend relationship in error messages.
+        friend: Label for the friend field of a friend relationship in error messages.
       trace:
-        description: '{{identical|Description}}'
+        user: Label for the user field of a GPS trace in error messages.
+        visible: Label for the visible field of a GPS trace in error messages.
+        name: Label for the filename field of a GPS trace in forms and error messages.
+        size: Label for the size field of a GPS trace in error messages.
+        latitude: Label for the latitude field of a GPS trace in error messages.
+        longitude: Label for the longitude field of a GPS trace in error messages.
+        public: Label for the public field of a GPS trace in error messages.
+        description: Label for the description field of a GPS trace in forms and error messages.
+        gpx_file: Label for the GPS trace file upload field.
+        visibility: Label for the visibility field of a GPS trace in forms and error messages.
+        tagstring: Label for the tags field of a GPS trace in forms and error messages.
+      message:
+        sender: Label for the sender field of a message in error messages.
+        title: Label for the subject field of a message in forms and error messages.
+        body: Label for the body field of a message in error messages.
+        recipient: Label for the recipient field of a message in error messages.
+      redaction:
+        title: Label for the title field of a redaction in forms and error messages.
+        description: Label for the description field of a redaction in forms and error messages.
+      report:
+        category: Label for the category selector in the report form.
+        details: Label for the details field in the report form.
+      user:
+        auth_provider: Label for the authentication provider field in user forms and error messages.
+        auth_uid: Label for the authentication UID field in user forms and error messages.
+        email: Label for the email address field in user forms and error messages.
+        new_email: Label for the new email address field in user forms and error messages.
+        active: Label for the active status field in user forms and error messages.
+        display_name: Label for the display name field in user forms and error messages.
+        description: Label for the profile description field in user forms and error messages.
+        company: Label for the company field in user forms and error messages.
+        home_lat: Label for the home latitude field in user forms and error messages.
+        home_lon: Label for the home longitude field in user forms and error messages.
+        home_location_name: Label for the home location name field in user forms and error messages.
+        languages: Label for the preferred languages field in user forms and error messages.
+        preferred_editor: Label for the preferred editor field in user forms and error messages.
+        pass_crypt: Label for the password field in user forms and error messages.
+        pass_crypt_confirmation: Label for the confirm password field in user forms and error messages.
+    help:
+      doorkeeper/application:
+        confidential: Help text for the confidential application field in Doorkeeper OAuth application forms.
+        redirect_uri: Help text for the redirect URIs field in Doorkeeper OAuth application forms.
+      trace:
+        tagstring: Help text for the tags field in GPS trace forms, explaining the format.
+      user_block:
+        reason: Help text for the reason field when creating or editing a user block.
+        needs_view: Help text for the 'needs view' checkbox when creating or editing a user block.
+      user:
+        new_email: Help text for the new email address field, noting it is not displayed publicly.
+  attributes:
+    client_application:
+      name: Label for the application name field on the OAuth1 client application form.
+      url: Label for the main application URL field on the OAuth1 client application form.
+      callback_url: Label for the callback URL field on the OAuth1 client application form.
+      support_url: Label for the support URL field on the OAuth1 client application form.
+      allow_read_prefs: Label for the 'read user preferences' permission checkbox on the OAuth1 application form.
+      allow_write_prefs: Label for the 'modify user preferences' permission checkbox on the OAuth1 application form.
+      allow_write_diary: Label for the 'create diary entries and comments' permission checkbox on the OAuth1 application form.
+      allow_write_api: Label for the 'modify the map' permission checkbox on the OAuth1 application form.
+      allow_write_changeset_comments: Label for the 'comment on changesets' permission checkbox on the OAuth1 application form.
+      allow_read_gpx: Label for the 'read private GPS traces' permission checkbox on the OAuth1 application form.
+      allow_write_gpx: Label for the 'upload GPS traces' permission checkbox on the OAuth1 application form.
+      allow_write_notes: Label for the 'modify notes' permission checkbox on the OAuth1 application form.
+    diary_comment:
+      body: Form field label for the body text of a diary comment.
+    diary_entry:
+      user: Form field label for the user associated with a diary entry.
+      title: Form field label for the subject/title of a diary entry.
+      body: Form field label for the body text of a diary entry.
+      latitude: Form field label for the latitude coordinate of a diary entry location.
+      longitude: Form field label for the longitude coordinate of a diary entry location.
+      language_code: Form field label for the language selection of a diary entry.
+    doorkeeper/application:
+      name: Form field label for the application name on the OAuth2 application registration form.
+      redirect_uri: Form field label for the redirect URIs on the OAuth2 application form.
+      confidential: Form field label for the confidential application checkbox on the OAuth2 application form.
+      scopes: Form field label for the permissions/scopes on the OAuth2 application form.
+    friend:
+      user: Form field label for the user in a friendship relationship.
+      friend: Form field label for the friend in a friendship relationship.
+    trace:
+      user: Form field label for the owner of a GPS trace.
+      visible: Form field label for the visibility flag of a GPS trace.
+      name: Form field label for the filename of a GPS trace.
+      size: Form field label for the file size of a GPS trace.
+      latitude: Form field label for the starting latitude of a GPS trace.
+      longitude: Form field label for the starting longitude of a GPS trace.
+      public: Form field label for the public flag of a GPS trace.
+      description: "{{identical|Description}}"
+      gpx_file: Label for the file input field on the GPS trace upload form.
+      visibility: Form field label for the visibility setting of a GPS trace.
+      tagstring: Form field label for the tags of a GPS trace.
+    message:
+      sender: Form field label for the sender of a message.
+      title: Form field label for the subject of a message.
+      body: Form field label for the body text of a message.
+      recipient: Form field label for the recipient of a message.
+    redaction:
+      title: Form field label for the title of a redaction.
+      description: Form field label for the description of a redaction.
+    report:
+      category: Form field label for the category/reason selector on the report form.
+      details: Form field label for the free-text details field on the report form.
+    user:
+      auth_provider: Form field label for the authentication provider on the user account settings page.
+      auth_uid: Form field label for the authentication UID on the user account settings page.
+      email: Form field label for the email address field.
+      new_email: Form field label for the new email address field on the account settings page.
+      active: Form field label for the active status flag of a user.
+      display_name: Form field label for the publicly visible username.
+      description: Form field label for the profile description text.
+      company: Form field label for the company/organisation affiliation on the user profile.
+      home_lat: Form field label for the home location latitude.
+      home_lon: Form field label for the home location longitude.
+      home_location_name: Form field label for the home location name.
+      languages: Form field label for the preferred languages setting.
+      preferred_editor: Form field label for the preferred map editor setting.
+      pass_crypt: Form field label for the password field.
+      pass_crypt_confirmation: Form field label for the password confirmation field.
+  help:
+    doorkeeper/application:
+      confidential: Help text below the confidential checkbox on the OAuth2 application form, explaining when an app is considered confidential.
+      redirect_uri: Help text below the redirect URIs field on the OAuth2 application form.
+    trace:
+      tagstring: Help text below the tags field on the GPS trace form, indicating comma-separated format.
+    user_block:
+      reason: Help text below the reason field on the user block form, advising moderators on tone and detail.
+      needs_view: Help text below the 'needs view' checkbox on the user block form, explaining what it means.
+    user:
+      new_email: Help text below the new email address field, noting it is never displayed publicly.
+  datetime:
+    distance_in_words_ago:
+      about_x_hours:
+        one: Relative time string. %{count} is the number of hours.
+        other: Relative time string. %{count} is the number of hours.
+      about_x_months:
+        one: Relative time string. %{count} is the number of months.
+        other: Relative time string. %{count} is the number of months.
+      about_x_years:
+        one: Relative time string. %{count} is the number of years.
+        other: Relative time string. %{count} is the number of years.
+      almost_x_years:
+        one: Relative time string. %{count} is the number of years.
+        other: Relative time string. %{count} is the number of years.
+      half_a_minute: Relative time string for approximately 30 seconds ago.
+      less_than_x_seconds:
+        one: Relative time string. %{count} is the number of seconds.
+        other: Relative time string. %{count} is the number of seconds.
+      less_than_x_minutes:
+        one: Relative time string. %{count} is the number of minutes.
+        other: Relative time string. %{count} is the number of minutes.
+      over_x_years:
+        one: Relative time string. %{count} is the number of years.
+        other: Relative time string. %{count} is the number of years.
+      x_seconds:
+        one: Relative time string. %{count} is the number of seconds.
+        other: Relative time string. %{count} is the number of seconds.
+      x_minutes:
+        one: Relative time string. %{count} is the number of minutes.
+        other: Relative time string. %{count} is the number of minutes.
+      x_days:
+        one: Relative time string. %{count} is the number of days.
+        other: Relative time string. %{count} is the number of days.
+      x_months:
+        one: Relative time string. %{count} is the number of months.
+        other: Relative time string. %{count} is the number of months.
+      x_years:
+        one: Relative time string. %{count} is the number of years.
+        other: Relative time string. %{count} is the number of years.
   printable_name:
-    with_date_html: '{{Optional|Only translate if the conventional format for indicating
-      the dates associated with something would different punctuation or non-ASCII
-      punctuation, or if the dates would be prepended.}}'
+    version: Label for a version number of a map element (node/way/relation). %{version} is the integer version number. Shown in the element history navigation bar.
+    with_name_html: Combines a feature name and its numeric ID in parentheses. %{name} is the feature name (e.g. from a name tag), %{id} is the numeric element ID. Used in browse and changeset element lists.
+    with_date_html: "{{Optional|Only translate if the conventional format for indicating the dates associated with something would use different punctuation or non-ASCII punctuation, or if the dates would be prepended.}}"
+    current_and_old_links_html: Combines a link to the current version and a link to the old version of a map element. %{current_link} is the current-version link, %{old_link} is the old-version link. Used in changeset element lists.
   editor:
+    default: Option label in the preferred editor dropdown for the site default. %{name} is the name of the currently configured default editor.
     id:
       name: |-
-        The term '''iD''' (with a lowercase initial and a capital second letter) is the actual name of an online map editor for OpenStreepMap or similar map editing projects.
+        The term '''iD''' (with a lowercase initial and a capital second letter) is the actual name of an online map editor for OpenStreetMap or similar map editing projects.
         : ''It is '''not''' meaning or abbreviating "identifier".'' Do not change it!
       description: |-
-        The term '''iD''' (with a lowercase initial and a capital second letter) is the actual name of an online map editor for OpenStreepMap or similar map editing projects.
+        The term '''iD''' (with a lowercase initial and a capital second letter) is the actual name of an online map editor for OpenStreetMap or similar map editing projects.
         : ''It is '''not''' meaning or abbreviating "identifier".'' Do not change it!
+    remote:
+      name: Name of the Remote Control editor option (used with JOSM, Potlatch, Merkaartor).
+      description: Description of the Remote Control editor option shown in the editor selector.
   auth:
     providers:
-      apple: |-
-        {{Optional}}
-        {{doc-important|This is the name of Apple the computer company, not a literal apple.}}
+      none: Option label in the authentication provider selector meaning no external provider.
+      openid: "{{doc-important|OpenID is a technical standard name. Do not translate.}}"
+      google: "{{doc-important|Google is a company name. Do not translate.}}"
+      apple: "{{doc-important|Apple is a company name. Do not translate.}}"
+      facebook: "{{doc-important|Facebook is a company name. Do not translate.}}"
+      microsoft: "{{doc-important|Microsoft is a company name. Do not translate.}}"
+      github: "{{doc-important|GitHub is a product name. Do not translate.}}"
+      wikipedia: "{{doc-important|Wikipedia is a proper name. Do not translate.}}"
+      openstreetmap: "{{doc-important|OpenStreetMap is a proper name. Do not translate.}}"
   api:
     notes:
+      comment:
+        opened_at_html: Shown in the note API/RSS output for the creation event. %{when} is a relative time string.
+        opened_at_by_html: Shown in the note API/RSS output for the creation event with attribution. %{when} is a relative time string, %{user} is the username.
+        commented_at_html: Shown in the note API/RSS output for a comment event. %{when} is a relative time string.
+        commented_at_by_html: Shown in the note API/RSS output for a comment event with attribution. %{when} is a relative time string, %{user} is the username.
+        closed_at_html: Shown in the note API/RSS output for the resolution event. %{when} is a relative time string.
+        closed_at_by_html: Shown in the note API/RSS output for the resolution event with attribution. %{when} is a relative time string, %{user} is the username.
+        reopened_at_html: Shown in the note API/RSS output for the reactivation event. %{when} is a relative time string.
+        reopened_at_by_html: Shown in the note API/RSS output for the reactivation event with attribution. %{when} is a relative time string, %{user} is the username.
+      rss:
+        title: Title of the RSS feed for all map notes.
+        description_all: Description of the RSS feed listing all notes.
+        description_area: Description of the RSS feed for notes in a geographic bounding box. %{min_lat}, %{min_lon}, %{max_lat}, %{max_lon} are the bounding box coordinates.
+        description_item: Description of the RSS feed for a single note. %{id} is the note ID.
+        opened: RSS item title for a newly opened note. %{place} is a human-readable place name near the note.
+        commented: RSS item title for a new comment on a note. %{place} is a human-readable place name near the note.
+        closed: RSS item title for a closed/resolved note. %{place} is a human-readable place name near the note.
+        reopened: RSS item title for a reactivated note. %{place} is a human-readable place name near the note.
       entry:
         comment: Used as heading. Translate as a noun.
+        full: Link label to view the full note detail page.
   accounts:
+    show:
+      title: Page title for the account settings page.
+      my_account: Heading on the account settings page.
+      current email address: Label for the current email address section on the account settings page.
+      external auth: Label for the external authentication section on the account settings page.
+      contributor_terms:
+        heading: Section heading for the Contributor Terms section on the account settings page.
+        agreed: Status message shown when the user has agreed to the Contributor Terms. %{date} is the date of agreement.
+        not_agreed: Status message shown when the user has not yet agreed to the Contributor Terms.
+        agreed_with_pd: Status message shown when the user has declared their contributions to be in the Public Domain.
+        link: "{{Optional}} URL to the Contributor Terms page."
+        link text: Link text for the 'what is this?' link next to the Contributor Terms section.
+        not_agreed_with_pd: Status message shown when the user has not declared their contributions to be in the Public Domain.
+        review: Button label to review the Contributor Terms (for users who have already agreed).
+        review_and_accept: Button label to review and accept the Contributor Terms (for users who have not yet agreed).
+        consider_pd: Button label to declare contributions as Public Domain.
+      terms_of_use:
+        heading: Section heading for the Terms of Use section on the account settings page.
+        agreed: Status message shown when the user has agreed to the Terms of Use. %{date} is the date of agreement.
+        not_agreed: Status message shown when the user has not yet agreed to the Terms of Use.
+        review: Button label to review the Terms of Use (for users who have already agreed).
+        review_and_accept: Button label to review and accept the Terms of Use (for users who have not yet agreed).
+      save changes button: Submit button label on the account settings form.
+      delete_account: Link label to navigate to the account deletion page.
+    go_public:
+      heading: Section heading for the 'make edits public' section.
+      currently_not_public: Explanatory text shown to users whose edits are still anonymous.
+      only_public_can_edit: Notice that only public users can edit map data since the API 0.6 changeover.
+      find_out_why_html: Wrapper for the 'find out why' link. %{link} is the link.
+      find_out_why: Link text for the 'find out why anonymous edits are no longer allowed' link.
+      find_out_why_url: "{{Optional}} URL for the 'find out why' link."
+      email_not_revealed: Reassurance that making edits public does not reveal the user's email address.
+      not_reversible: Warning that making edits public cannot be undone.
+      make_edits_public_button: Button label to make all edits public.
+    update:
+      success_confirm_needed: Flash message shown after a successful account update when the new email address still needs to be confirmed.
+      success: Flash message shown after a successful account update.
+    destroy:
+      success: Flash message shown after the user's account has been successfully deleted.
     deletions:
       show:
-        cancel: '{{identical|Cancel}}'
-  changesets:
+        title: Page title for the delete account page.
+        warning: Warning message on the delete account page that the deletion is final.
+        delete_account: Button label to confirm account deletion.
+        delete_introduction: Introductory text on the delete account page listing what will happen.
+        delete_profile: Bullet point explaining that profile information will be removed on account deletion.
+        delete_display_name: Bullet point explaining that the display name will be removed and can be reused.
+        retain_caveats: Introductory text for the list of information retained after account deletion.
+        retain_edits: Bullet point explaining that map edits are retained after account deletion.
+        retain_traces: Bullet point explaining that uploaded GPS traces are retained after account deletion.
+        retain_diary_entries: Bullet point explaining that diary entries and comments are retained but hidden after account deletion.
+        retain_notes: Bullet point explaining that map notes and comments are retained but hidden after account deletion.
+        retain_changeset_discussions: Bullet point explaining that changeset discussions are retained after account deletion.
+        retain_email: Bullet point explaining that the email address is retained after account deletion.
+        recent_editing_html: Message shown when the account cannot be deleted yet due to recent editing activity. %{time} is the waiting period.
+        confirm_delete: Confirmation prompt before deleting the account.
+        cancel: Button label to cancel account deletion and return to the previous page.
+    terms:
+      show:
+        title: Page title for the contributor terms page.
+        heading: Heading for the contributor terms page.
+        heading_ct: Subheading for the contributor terms section.
+        read and accept with tou: Instructions to read and accept both the contributor agreement and terms of use.
+        contributor_terms_explain: Explanation of what the contributor agreement covers.
+        read_ct: Checkbox label to confirm reading and agreeing to the contributor terms.
+        tou_explain:
+          html: Explanation of the Terms of Use with a link. %{tou_link} is the Terms of Use as a link.
+          tou: Link text for the Terms of Use in the terms explanation.
+        read_tou: Checkbox label to confirm reading and agreeing to the Terms of Use.
+        guidance_info_html: Text with links to a readable summary and informal translations of the terms. %{readable_summary_link} and %{informal_translations_link} are links.
+        readable_summary: Link text for the human-readable summary of the contributor terms.
+        informal_translations: Link text for the informal translations of the contributor terms.
+        continue: Button label to continue after accepting the contributor terms.
+        cancel: Button label to cancel and decline the contributor terms.
+        you need to accept or decline: Validation message shown when the user has not checked either the accept or decline checkbox.
+        legale_select: Label for the country of residence selector on the contributor terms page.
+        legale_names:
+          france: Option label for France in the country of residence selector.
+          italy: Option label for Italy in the country of residence selector.
+          rest_of_world: Option label for all other countries in the country of residence selector.
+      update:
+        terms accepted: Flash message shown after the user accepts the contributor terms.
+      terms_declined_flash:
+        terms_declined_html: Flash message shown after the user declines the contributor terms. %{terms_declined_link} is a link.
+        terms_declined_link: Link text for the wiki page about declining contributor terms.
+        terms_declined_url: URL for the wiki page about declining contributor terms.
+    pd_declarations:
+      show:
+        title: Page title for the public domain declaration page.
+        consider_pd: Checkbox label to declare contributions as public domain.
+        consider_pd_why: Link text for the 'why would I want this?' link on the public domain declaration page.
+        consider_pd_why_url: URL for the FAQ page about public domain contributions.
+        confirm: Button label to confirm the public domain declaration.
+      create:
+        successfully_declared: Flash message shown after successfully declaring contributions as public domain.
+        already_declared: Flash message shown when the user has already made the public domain declaration.
+        did_not_confirm: Flash message shown when the user submitted the form without checking the confirmation checkbox.
+  deletions:
+    show:
+      title: Page title for the account deletion confirmation page.
+      warning: Bold warning text at the top of the account deletion page.
+      delete_account: Submit button label on the account deletion confirmation page.
+      delete_introduction: Introductory sentence before the list of what will be deleted.
+      delete_profile: List item explaining that profile information will be removed on account deletion.
+      delete_display_name: List item explaining that the display name will be removed and can be reused.
+      retain_caveats: Introductory sentence before the list of data that is retained after deletion.
+      retain_edits: List item explaining that map edits are retained after account deletion.
+      retain_traces: List item explaining that uploaded GPS traces are retained after account deletion.
+      retain_diary_entries: List item explaining that diary entries and comments are retained but hidden after account deletion.
+      retain_notes: List item explaining that map notes and note comments are retained but hidden after account deletion.
+      retain_changeset_discussions: List item explaining that changeset discussions are retained after account deletion.
+      retain_email: List item explaining that the email address is retained after account deletion.
+      recent_editing_html: Warning shown when the account cannot yet be deleted due to recent editing activity. %{time} is the time remaining before deletion is possible.
+      confirm_delete: Confirmation prompt shown before the final delete button.
+      cancel: "{{identical|Cancel}}"
+  terms:
+    show:
+      title: Page title for the contributor terms acceptance page.
+      heading: Main heading on the contributor terms page.
+      heading_ct: Sub-heading for the contributor terms section.
+      read and accept with tou: Instruction text asking the user to read both the contributor agreement and terms of use before checking the checkboxes.
+      contributor_terms_explain: Brief explanation of what the contributor agreement covers.
+      read_ct: Label for the checkbox confirming the user has read and agrees to the contributor terms.
+      tou_explain:
+        html: Explanation of the Terms of Use with a link. %{tou_link} is the link to the Terms of Use.
+        tou: Link text for the Terms of Use link in the tou_explain message.
+      read_tou: Label for the checkbox confirming the user has read and agrees to the Terms of Use.
+      guidance_info_html: Sentence pointing to additional guidance resources. %{readable_summary_link} and %{informal_translations_link} are links.
+      readable_summary: Link text for the human-readable summary of the contributor terms.
+      informal_translations: Link text for the informal translations of the contributor terms.
+      continue: Button label to continue after accepting the terms.
+      cancel: "{{identical|Cancel}}"
+      you need to accept or decline: Flash message shown when the user tries to continue without accepting or declining the terms.
+      legale_select: Label for the country-of-residence selector on the contributor terms page.
+      legale_names:
+        france: "{{Optional}} Country name option in the legale selector."
+        italy: "{{Optional}} Country name option in the legale selector."
+        rest_of_world: Option in the legale selector for all countries other than France and Italy.
+    update:
+      terms accepted: Flash message shown after the user successfully accepts the contributor terms.
+    terms_declined_flash:
+      terms_declined_html: Flash message shown when the user declines the contributor terms. %{terms_declined_link} is a link to a wiki page with more information.
+      terms_declined_link: Link text for the wiki page linked in the terms_declined_html message.
+      terms_declined_url: "{{Optional}} URL for the terms declined wiki page."
+  pd_declarations:
+    show:
+      title: Page title for the Public Domain declaration page.
+      consider_pd: Label for the checkbox on the Public Domain declaration page.
+      consider_pd_why: Link text for the 'why would I want this?' link on the Public Domain declaration page.
+      consider_pd_why_url: "{{Optional}} URL for the Public Domain FAQ page."
+      confirm: Submit button label on the Public Domain declaration page.
+    create:
+      successfully_declared: Flash message shown after successfully declaring contributions as Public Domain.
+      already_declared: Flash message shown when the user has already declared their contributions as Public Domain.
+      did_not_confirm: Flash message shown when the user submitted the form without checking the confirmation checkbox.
+  browse:
+    deleted_ago_by_html: Shown on element browse pages when the element has been deleted. %{time_ago} is a relative time, %{user} is the username.
+    edited_ago_by_html: Shown on element browse pages for the last edit. %{time_ago} is a relative time, %{user} is the username.
+    version: Label for the version number of a map element on the browse page.
+    redacted_version: Label shown instead of a version number when a version has been redacted.
+    in_changeset: Label for the changeset link on the element browse page.
+    anonymous: Shown in place of a username when the editor was anonymous.
+    no_comment: Shown in place of a changeset comment when none was provided.
+    part_of: Label for the 'part of' section listing relations that contain this element.
+    part_of_relations:
+      one: Count of relations containing this element. %{count} is the number.
+      other: Count of relations containing this element. %{count} is the number.
+    part_of_ways:
+      one: Count of ways containing this node. %{count} is the number.
+      other: Count of ways containing this node. %{count} is the number.
+    download_xml: Link label to download the element as XML.
+    view_unredacted_history: Link label shown to moderators to view the unredacted history of an element.
+    location: Label for the coordinates section on the element browse page.
+    common_details:
+      coordinates_html: Formatted coordinates string. %{latitude} and %{longitude} are decimal degree values.
+    node:
+      title_html: Page title for a node browse page. %{name} is the node's display name.
+    way:
+      title_html: Page title for a way browse page. %{name} is the way's display name.
+      nodes: Section heading for the list of nodes that make up a way.
+      nodes_count:
+        one: Count of nodes in a way. %{count} is the number.
+        other: Count of nodes in a way. %{count} is the number.
+      also_part_of_html:
+        one: Note that a node is also part of another way. %{related_ways} is a link to the related way.
+        other: Note that a node is also part of other ways. %{related_ways} is a list of links to the related ways.
+    relation:
+      title_html: Page title for a relation browse page. %{name} is the relation's display name.
+      members: Section heading for the list of members of a relation.
+      members_count:
+        one: Count of members in a relation. %{count} is the number.
+        other: Count of members in a relation. %{count} is the number.
+    relation_member:
+      entry_html: A relation member entry without a role. %{type} is the element type (Node/Way/Relation), %{name} is the element's display name.
+      entry_role_html: A relation member entry with a role. %{type} is the element type, %{name} is the display name, %{role} is the member's role.
+      type:
+        node: Element type label for a node member of a relation.
+        way: Element type label for a way member of a relation.
+        relation: Element type label for a relation member of a relation.
+    containing_relation:
+      entry_role_html: A containing relation entry. %{relation_name} is the relation's display name, %{relation_role} is the role of the current element in that relation.
+    not_found:
+      title: Page title shown when a map element cannot be found.
+    timeout:
+      title: Page title shown when loading a map element times out.
+      sorry: Error message shown when loading element data times out. %{type} is the element type, %{id} is the element ID.
+      type:
+        node: Element type name used in the timeout error message.
+        way: Element type name used in the timeout error message.
+        relation: Element type name used in the timeout error message.
+        changeset: Element type name used in the timeout error message.
+        note: Element type name used in the timeout error message.
+    redacted:
+      redaction: Label for a redaction reference. %{id} is the redaction ID.
+      message_html: Message shown when a version of an element has been redacted. %{version} is the version number, %{type} is the element type, %{redaction_link} is a link to the redaction record.
+      type:
+        node: Element type name used in the redaction message.
+        way: Element type name used in the redaction message.
+        relation: Element type name used in the redaction message.
+    start_rjs:
+      feature_warning: Confirmation dialog shown in JavaScript before loading a large number of map features. %{num_features} is the count.
+      feature_error: Error message shown in JavaScript when map features fail to load. %{message} is the error detail.
+      load_data: Button label in the map data layer to trigger loading of map data.
+      loading: Visually hidden loading indicator text used as a spinner label.
+    tag_details:
+      tags: Section heading for the tags table on element browse pages.
+      wiki_link:
+        key: Tooltip/aria-label for the link to the wiki page for a tag key. %{key} is the tag key.
+        tag: Tooltip/aria-label for the link to the wiki page for a key=value tag. %{key} is the key, %{value} is the value.
+      wikidata_link: Tooltip/aria-label for the link to a Wikidata item. %{page} is the Wikidata item identifier.
+      wikidata_preview:
+        one: Tooltip for the Wikidata item preview image.
+        other: Tooltip for the Wikidata items preview images.
+      wikipedia_link: Tooltip/aria-label for the link to a Wikipedia article. %{page} is the article title.
+      wikimedia_commons_link: Tooltip/aria-label for the link to a Wikimedia Commons item. %{page} is the item name.
+      telephone_link: Tooltip/aria-label for a telephone number link. %{phone_number} is the phone number.
+      colour_preview: Tooltip/aria-label for a colour swatch preview. %{colour_value} is the CSS colour value.
+      email_link: Tooltip/aria-label for an email address link. %{email} is the email address.
+    versions_navigation:
+      node: Label for the node element type in the version history navigation breadcrumb.
+      way: Label for the way element type in the version history navigation breadcrumb.
+      relation: Label for the relation element type in the version history navigation breadcrumb.
+      history: Link label to the full history page in the version navigation breadcrumb.
+      version: Label for a specific version in the version navigation. %{version} is the version number.
+      versions_label: Label preceding the list of version links in the version navigation.
+  feature_queries:
+    show:
+      title: Page title for the query features sidebar panel.
+      introduction: Instruction text shown in the query features panel before the user clicks the map.
+      nearby: Section heading for nearby features in the query results panel.
+      enclosing: Section heading for enclosing features (areas containing the clicked point) in the query results panel.
+  old_elements:
     index:
+      node:
+        title_html: Page title for the node history page. %{name} is the node's display name.
+      way:
+        title_html: Page title for the way history page. %{name} is the way's display name.
+      relation:
+        title_html: Page title for the relation history page. %{name} is the relation's display name.
+      older_versions: Pagination link label to navigate to older versions in the element history.
+      newer_versions: Pagination link label to navigate to newer versions in the element history.
+    actions:
+      view_redacted_data: Button label shown to moderators to view the redacted data of an element version.
+      view_redaction_message: Button label shown to moderators to view the redaction message for an element version.
+  nodes:
+    not_found_message:
+      sorry: Error message shown when a node cannot be found. %{id} is the node ID.
+    timeout:
+      sorry: Error message shown when loading node data times out. %{id} is the node ID.
+  old_nodes:
+    not_found_message:
+      sorry: Error message shown when a specific version of a node cannot be found. %{id} is the node ID, %{version} is the version number.
+    timeout:
+      sorry: Error message shown when loading node history times out. %{id} is the node ID.
+  ways:
+    not_found_message:
+      sorry: Error message shown when a way cannot be found. %{id} is the way ID.
+    timeout:
+      sorry: Error message shown when loading way data times out. %{id} is the way ID.
+  old_ways:
+    not_found_message:
+      sorry: Error message shown when a specific version of a way cannot be found. %{id} is the way ID, %{version} is the version number.
+    timeout:
+      sorry: Error message shown when loading way history times out. %{id} is the way ID.
+  relations:
+    not_found_message:
+      sorry: Error message shown when a relation cannot be found. %{id} is the relation ID.
+    timeout:
+      sorry: Error message shown when loading relation data times out. %{id} is the relation ID.
+  relation_members:
+    not_found_message:
+      sorry: Error message shown when a relation cannot be found on the relation members page. %{id} is the relation ID.
+    timeout:
+      sorry: Error message shown when loading relation data times out on the members page. %{id} is the relation ID.
+  old_relations:
+    not_found_message:
+      sorry: Error message shown when a specific version of a relation cannot be found. %{id} is the relation ID, %{version} is the version number.
+    timeout:
+      sorry: Error message shown when loading relation history times out. %{id} is the relation ID.
+  old_relation_members:
+    not_found_message:
+      sorry: Error message shown when a specific version of a relation cannot be found on the members page. %{id} is the relation ID, %{version} is the version number.
+    timeout:
+      sorry: Error message shown when loading relation members times out. %{id} is the relation ID.
+  changeset_comments:
+    feeds:
+      comment:
+        comment: RSS item title for a new changeset comment. %{changeset_id} is the changeset ID, %{author} is the commenter's username.
+        commented_at_by_html: Timestamp line in the changeset comment feed. %{when} is a relative time, %{user} is the username.
+      show:
+        title_all: Title of the RSS feed for all changeset discussions.
+        title_particular: Title of the RSS feed for a specific changeset discussion. %{changeset_id} is the changeset ID.
+      timeout:
+        sorry: Error message shown when loading changeset comments times out.
+  changesets:
+    changeset_line:
+      comments:
+        one: Comment count badge on a changeset list item. %{count} is the number.
+        other: Comment count badge on a changeset list item. %{count} is the number.
+      changes:
+        one: Change count badge on a changeset list item. %{count} is the number.
+        other: Change count badge on a changeset list item. %{count} is the number.
+      n_elements_created:
+        one: Count of elements created in a changeset. %{count} is the number.
+        other: Count of elements created in a changeset. %{count} is the number.
+      n_elements_modified:
+        one: Count of elements modified in a changeset. %{count} is the number.
+        other: Count of elements modified in a changeset. %{count} is the number.
+      n_elements_deleted:
+        one: Count of elements deleted in a changeset. %{count} is the number.
+        other: Count of elements deleted in a changeset. %{count} is the number.
+    index:
+      title: Page title for the changesets list page.
+      title_user: Page title for the changesets list filtered by a specific user. %{user} is the username.
+      title_user_link_html: Page title with a linked username. %{user_link} is the linked username.
+      title_followed: Page title for changesets by users the current user follows.
+      title_nearby: Page title for changesets by nearby users.
+      empty: Message shown when no changesets are found.
+      empty_area: Message shown when no changesets are found in the current map area.
+      empty_user: Message shown when no changesets are found for the specified user.
+      no_more: Message shown when there are no more changesets to load.
+      no_more_area: Message shown when there are no more changesets in the current area.
+      no_more_user: Message shown when there are no more changesets for the specified user.
+      older_changesets: Pagination link label to navigate to older changesets.
+      newer_changesets: Pagination link label to navigate to newer changesets.
       feed:
-        cc0: '{{Optional}}'
-        cc0_url: '{{Optional}}'
+        cc0: "{{Optional}} Creative Commons CC0 licence name used in the changeset Atom feed."
+        cc0_url: "{{Optional}} URL for the CC0 licence used in the changeset Atom feed."
+        title: Atom feed entry title for a changeset without a comment. %{id} is the changeset ID.
+        title_comment: Atom feed entry title for a changeset with a comment. %{id} is the changeset ID, %{comment} is the changeset comment.
+        created: Label for the creation date in the changeset Atom feed.
+        closed: Label for the closing date in the changeset Atom feed.
+        belongs_to: Label for the author in the changeset Atom feed.
+    show:
+      title: Page title for the changeset detail page. %{id} is the changeset ID.
+      created: Label and value for the creation time of a changeset. %{when} is the formatted date/time.
+      closed: Label and value for the closing time of a changeset. %{when} is the formatted date/time.
+      created_ago_html: Relative creation time shown on the changeset page. %{time_ago} is a relative time string.
+      closed_ago_html: Relative closing time shown on the changeset page. %{time_ago} is a relative time string.
+      created_ago_by_html: Relative creation time with attribution. %{time_ago} is a relative time string, %{user} is the username.
+      closed_ago_by_html: Relative closing time with attribution. %{time_ago} is a relative time string, %{user} is the username.
+      discussion: Section heading for the discussion/comments section on the changeset page.
+      join_discussion: Link label shown to logged-out users to log in and join the changeset discussion.
+      still_open: Notice shown when the changeset is still open and discussion is not yet available.
+      subscribe: Button label to subscribe to changeset discussion notifications.
+      unsubscribe: Button label to unsubscribe from changeset discussion notifications.
+      comment_by_html: Attribution line for a changeset comment. %{user} is the commenter's username, %{time_ago} is a relative time.
+      hidden_comment_by_html: Attribution line for a hidden changeset comment (visible to moderators). %{user} is the username, %{time_ago} is a relative time.
+      hide_comment: Link label for moderators to hide a changeset comment.
+      unhide_comment: Link label for moderators to unhide a changeset comment.
+      comment: Submit button label on the changeset comment form.
+      changesetxml: Link label to download the changeset metadata as XML.
+      osmchangexml: Link label to download the changeset diff as osmChange XML.
+    paging_nav:
+      nodes_title: Section heading for the nodes list in the changeset element pager.
+      nodes_paginated: Section heading with pagination info for the nodes list. %{x} and %{y} are the range, %{count} is the total.
+      ways_title: Section heading for the ways list in the changeset element pager.
+      ways_paginated: Section heading with pagination info for the ways list. %{x} and %{y} are the range, %{count} is the total.
+      relations_title: Section heading for the relations list in the changeset element pager.
+      relations_paginated: Section heading with pagination info for the relations list. %{x} and %{y} are the range, %{count} is the total.
+      range: Pagination range indicator. %{x} and %{y} are the start and end of the current page, %{count} is the total.
+    not_found_message:
+      sorry: Error message shown when a changeset cannot be found. %{id} is the changeset ID.
+    timeout:
+      sorry: Error message shown when loading changesets times out.
+  changeset_subscriptions:
+    show:
+      subscribe:
+        heading: Confirmation heading on the changeset subscription page.
+        button: Button label to confirm subscribing to a changeset discussion.
+      unsubscribe:
+        heading: Confirmation heading on the changeset unsubscription page.
+        button: Button label to confirm unsubscribing from a changeset discussion.
+    heading:
+      title: Heading showing the changeset ID on the subscription confirmation page. %{id} is the changeset ID.
+      created_by_html: Sub-heading showing who created the changeset and when. %{link_user} is a link to the user, %{created} is the creation date.
+    no_such_entry:
+      heading: Error heading when the changeset ID does not exist. %{id} is the ID.
+      body: Error body text when the changeset ID does not exist. %{id} is the ID.
+  dashboards:
+    contact:
+      km away: Distance label in kilometres on the dashboard nearby mapper card. %{count} is the distance.
+      m away: Distance label in metres on the dashboard nearby mapper card. %{count} is the distance.
+      latest_edit_html: Label for the latest edit entry on the dashboard nearby mapper card. %{ago} is a relative time.
+      no_edits: Shown on the dashboard nearby mapper card when the user has no edits.
+      view_changeset_details: Link label to view the changeset details from the dashboard nearby mapper card.
+    popup:
+      your location: Popup label for the user's own home location marker on the dashboard map.
+      nearby mapper: Popup label for a nearby mapper's marker on the dashboard map.
+      following: Popup label shown on a mapper's marker when the current user is following them.
+    show:
+      title: Page title for the user dashboard.
+      no_home_location_html: Message shown when the user has no home location set. %{edit_profile_link} is a link to the profile edit page.
+      edit_your_profile: Link text for the edit profile link in the no_home_location message.
+      followings: Section heading for the list of users the current user follows.
+      no followings: Message shown when the user is not following anyone.
+      nearby users: Section heading for the list of nearby users on the dashboard.
+      no nearby users: Message shown when there are no other nearby users.
+      followed_changesets: Link label for the changesets feed of followed users.
+      followed_diaries: Link label for the diary entries feed of followed users.
+      nearby_changesets: Link label for the changesets feed of nearby users.
+      nearby_diaries: Link label for the diary entries feed of nearby users.
+  diary_entries:
+    new:
+      title: Page title for the new diary entry form.
+    form:
+      location: Label for the location section on the diary entry form.
+      use_map_link: Link label to use the current map view to set the diary entry location.
+    index:
+      title: Page title for the all-users diary entries list.
+      title_followed: Page title for the diary entries list filtered to followed users.
+      title_nearby: Page title for the diary entries list filtered to nearby users.
+      user_title: Page title for a specific user's diary. %{user} is the username.
+      in_language_title: Page title for diary entries filtered by language. %{language} is the language name.
+      no_entries: Message shown when there are no diary entries to display.
+    page:
+      recent_entries: Section heading for the recent diary entries list on the diary index page.
+    edit:
+      title: Page title for the edit diary entry form.
+      marker_text: Label for the map marker used to set the diary entry location.
+    show:
+      title: Page title for a diary entry. %{user} is the author's username, %{title} is the entry title.
+      user_title: Heading showing the diary author's name. %{user} is the username.
+      discussion: Section heading for the comments/discussion on a diary entry.
+      subscribe: Button label to subscribe to a diary entry discussion.
+      unsubscribe: Button label to unsubscribe from a diary entry discussion.
+      leave_a_comment: Heading for the comment form on a diary entry.
+      login_to_leave_a_comment_html: Message shown to logged-out users prompting them to log in to comment. %{login_link} is a link.
+      login: Link text for the login link in the diary comment prompt.
+    no_such_entry:
+      title: Page title when a diary entry cannot be found.
+      heading: Heading when a diary entry cannot be found. %{id} is the entry ID.
+      body: Body text when a diary entry cannot be found. %{id} is the entry ID.
+    diary_entry:
+      posted_by_html: Attribution line for a diary entry. %{link_user} is the author as a link, %{created} is the date, %{language_link} is the language as a link.
+      updated_at_html: Line showing when a diary entry was last updated. %{updated} is the date.
+      full_entry: Link text to see the full diary entry from a truncated listing.
+      comment_link: Link text to comment on a diary entry.
+      reply_link: Link text to send a message to the diary entry author.
+      comment_count:
+        one: Singular count of comments on a diary entry. %{count} is the number.
+        other: Plural count of comments on a diary entry. %{count} is the number.
+      no_comments: Text shown when a diary entry has no comments.
+      edit_link: Link text to edit a diary entry (shown to the author).
+      hide_link: Link text to hide a diary entry (shown to moderators).
+      unhide_link: Link text to unhide a diary entry (shown to moderators).
+      confirm: Confirmation prompt before hiding or unhiding a diary entry.
+      report: Link text to report a diary entry.
+    diary_comment:
+      comment_from_html: Attribution line for a diary comment. %{link_user} is the commenter as a link, %{comment_created_at} is the date.
+      hide_link: Link text to hide a diary comment (shown to moderators).
+      unhide_link: Link text to unhide a diary comment (shown to moderators).
+      confirm: Confirmation prompt before hiding or unhiding a diary comment.
+      report: Link text to report a diary comment.
+    location:
+      location: Label for the location section on a diary entry.
+      coordinates: Format for displaying the diary entry location coordinates. %{latitude} and %{longitude} are the values.
+    feed:
+      user:
+        title: Title for the RSS/Atom feed of a specific user's diary entries. %{user} is the username.
+        description: Description for the RSS/Atom feed of a specific user's diary entries. %{user} is the username.
+      language:
+        title: Title for the RSS/Atom feed of diary entries in a specific language. %{language_name} is the language name.
+        description: Description for the RSS/Atom feed of diary entries in a specific language. %{language_name} is the language name.
+      all:
+        title: Title for the RSS/Atom feed of all diary entries.
+        description: Description for the RSS/Atom feed of all diary entries.
+    comments:
+      title: Title for the RSS/Atom feed of diary comments.
+      description: Description for the RSS/Atom feed of diary comments.
+    subscribe:
+      heading: Heading on the diary entry subscription confirmation page.
+      button: Button label to confirm subscribing to a diary entry discussion.
+    unsubscribe:
+      heading: Heading on the diary entry unsubscription confirmation page.
+      button: Button label to confirm unsubscribing from a diary entry discussion.
+    navigation:
+      in_language: Navigation link to diary entries in a specific language. %{language} is the language name.
+      my_diary: Navigation link to the user's own diary.
+      new: Navigation link to compose a new diary entry.
+      new_title: Tooltip for the new diary entry navigation link.
+    profile_diaries:
+      latest_diaries: Section heading for the latest diary entries on a user profile.
+      comments:
+        one: Singular count of comments on a diary entry in the profile diaries list. %{count} is the number.
+        other: Plural count of comments on a diary entry in the profile diaries list. %{count} is the number.
+      title_label: Column header for the diary entry title in the profile diaries table.
+      comments_label: Column header for the comment count in the profile diaries table.
+      date_label: Column header for the date in the profile diaries table.
+  show:
+    title: Page title for a diary entry. %{user} is the author's username, %{title} is the entry title.
+    user_title: Breadcrumb link label for the user's diary. %{user} is the username.
+    discussion: Section heading for the comments section on a diary entry page.
+    subscribe: Button label to subscribe to diary entry comment notifications.
+    unsubscribe: Button label to unsubscribe from diary entry comment notifications.
+    leave_a_comment: Heading above the comment form on a diary entry page.
+    login_to_leave_a_comment_html: Message shown to logged-out users. %{login_link} is a link to the login page.
+    login: Link text for the login link in the login_to_leave_a_comment message.
+  no_such_entry:
+    title: Page title when a diary entry or comment ID does not exist.
+    heading: Error heading when a diary entry ID does not exist. %{id} is the ID.
+    body: Error body text when a diary entry ID does not exist. %{id} is the ID.
+  diary_entry:
+    posted_by_html: Attribution line on a diary entry. %{link_user} is a link to the author, %{created} is the date, %{language_link} is a link to the language.
+    updated_at_html: Last-updated line on a diary entry. %{updated} is the date.
+    full_entry: Link label to view the full diary entry from a truncated list view.
+    comment_link: Link label to add a comment to a diary entry.
+    reply_link: Link label to send a private message to the diary entry author.
+    comment_count:
+      one: Comment count on a diary entry. %{count} is the number.
+      other: Comment count on a diary entry. %{count} is the number.
+    no_comments: Shown when a diary entry has no comments.
+    edit_link: Link label to edit a diary entry (shown to the author).
+    hide_link: Link label to hide a diary entry (shown to moderators).
+    unhide_link: Link label to unhide a diary entry (shown to moderators).
+    confirm: Confirmation prompt before hiding/unhiding a diary entry.
+    report: Link label to report a diary entry.
+  diary_comment:
+    comment_from_html: Attribution line for a diary comment. %{link_user} is a link to the commenter, %{comment_created_at} is the date.
+    hide_link: Link label to hide a diary comment (shown to moderators).
+    unhide_link: Link label to unhide a diary comment (shown to moderators).
+    confirm: Confirmation prompt before hiding/unhiding a diary comment.
+    report: Link label to report a diary comment.
+  location:
+    location: Label for the location line on a diary entry.
+    coordinates: Formatted coordinates on a diary entry. %{latitude} and %{longitude} are decimal degree values.
+  feed:
+    user:
+      title: Title of the RSS feed for a specific user's diary entries. %{user} is the username.
+      description: Description of the RSS feed for a specific user's diary entries. %{user} is the username.
+    language:
+      title: Title of the RSS feed for diary entries in a specific language. %{language_name} is the language name.
+      description: Description of the RSS feed for diary entries in a specific language. %{language_name} is the language name.
+    all:
+      title: Title of the RSS feed for all diary entries.
+      description: Description of the RSS feed for all diary entries.
+  comments:
+    title: Title of the RSS feed for diary entry comments.
+    description: Description of the RSS feed for diary entry comments.
+  subscribe:
+    heading: Confirmation heading on the diary entry subscription page.
+    button: Button label to confirm subscribing to a diary entry discussion.
+  unsubscribe:
+    heading: Confirmation heading on the diary entry unsubscription page.
+    button: Button label to confirm unsubscribing from a diary entry discussion.
+  navigation:
+    in_language: Navigation link label for diary entries in a specific language. %{language} is the language name.
+    my_diary: Navigation link label for the current user's own diary.
+    new: Navigation link label to compose a new diary entry.
+    new_title: Tooltip for the new diary entry navigation link.
+  profile_diaries:
+    latest_diaries: Section heading for the latest diary entries on a user profile page.
+    comments:
+      one: Comment count on a diary entry in the profile diaries list. %{count} is the number.
+      other: Comment count on a diary entry in the profile diaries list. %{count} is the number.
+    title_label: Column header for the diary entry title in the profile diaries table.
+    comments_label: Column header for the comments count in the profile diaries table.
+    date_label: Column header for the date in the profile diaries table.
+  errors:
+    contact:
+      contact_url: "{{Optional}} URL for the OpenHistoricalMap community contact page, used in error pages."
+      contact_url_title: Title attribute for the contact link on error pages.
+      contact: Link text for the contact link on error pages.
+      contact_the_community_html: Sentence on error pages inviting users to report bugs. %{contact_link} is the contact link.
+    bad_request:
+      title: Page title for the HTTP 400 Bad Request error page.
+      description: Description shown on the HTTP 400 Bad Request error page.
+    forbidden:
+      title: Page title for the HTTP 403 Forbidden error page.
+      description: Description shown on the HTTP 403 Forbidden error page.
+    internal_server_error:
+      title: Page title for the HTTP 500 Internal Server Error page.
+      description: Description shown on the HTTP 500 Internal Server Error page.
+    not_found:
+      title: Page title for the HTTP 404 Not Found error page.
+      description: Description shown on the HTTP 404 Not Found error page.
+  export:
+    show:
+      title: Page title for the embedded map export page.
+  follows:
+    show:
+      follow:
+        heading: Confirmation heading on the follow user page. %{user} is the username.
+        button: Button label to confirm following a user.
+      unfollow:
+        heading: Confirmation heading on the unfollow user page. %{user} is the username.
+        button: Button label to confirm unfollowing a user.
+    create:
+      success: Flash message shown after successfully following a user. %{name} is the username.
+      failed: Flash message shown when following a user fails. %{name} is the username.
+      already_followed: Flash message shown when trying to follow a user already being followed. %{name} is the username.
+      limit_exceeded: Flash message shown when the follow rate limit is exceeded.
+    destroy:
+      success: Flash message shown after successfully unfollowing a user. %{name} is the username.
+      not_followed: Flash message shown when trying to unfollow a user not being followed. %{name} is the username.
   geocoder:
     search:
       title:
-        latlon_url: '{{optional}}'
-        osm_nominatim_url: '{{optional}}'
-        osm_nominatim_reverse_url: '{{optional}}'
+        latlon: Label for the internal lat/lon search result source in the search results sidebar.
+        latlon_url: "{{Optional}} URL for the internal lat/lon search source."
+        osm_nominatim: Label for the Nominatim geocoder result source in the search results sidebar.
+        osm_nominatim_url: "{{Optional}} URL for the Nominatim geocoder."
+        osm_nominatim_reverse: Label for the reverse Nominatim geocoder result source.
+        osm_nominatim_reverse_url: "{{Optional}} URL for the reverse Nominatim geocoder."
     search_osm_nominatim:
+      prefix_format: Format string for a Nominatim search result name. %{name} is the feature name prefix.
       suffix_format: |-
-        {{Optional|Only translate if the conventional format for indicating the dates associated with something would different punctuation or non-ASCII punctuation.}}
+        {{Optional|Only translate if the conventional format for indicating the dates associated with something uses different punctuation.}}
 
         {{Identical|Date suffix format}}
       prefix:
+        aerialway:
+          cable_car: Name shown in search results for an aerialway=cable_car feature.
+          chair_lift: Name shown in search results for an aerialway=chair_lift feature.
+          drag_lift: Name shown in search results for an aerialway=drag_lift feature.
+          gondola: Name shown in search results for an aerialway=gondola feature.
+          magic_carpet: Name shown in search results for an aerialway=magic_carpet feature.
+          platter: Name shown in search results for an aerialway=platter feature.
+          pylon: Name shown in search results for an aerialway=pylon feature.
+          station: Name shown in search results for an aerialway=station feature.
+          t-bar: Name shown in search results for an aerialway=t-bar feature.
+          'yes': Name shown in search results for a generic aerialway feature.
+        aeroway:
+          aerodrome: Name shown in search results for an aeroway=aerodrome feature.
+          airstrip: Name shown in search results for an aeroway=airstrip feature.
+          apron: Name shown in search results for an aeroway=apron feature.
+          gate: Name shown in search results for an aeroway=gate feature.
+          hangar: Name shown in search results for an aeroway=hangar feature.
+          helipad: Name shown in search results for an aeroway=helipad feature.
+          holding_position: Name shown in search results for an aeroway=holding_position feature.
+          navigationaid: Name shown in search results for an aeroway=navigationaid feature.
+          parking_position: Name shown in search results for an aeroway=parking_position feature.
+          runway: Name shown in search results for an aeroway=runway feature.
+          taxilane: Name shown in search results for an aeroway=taxilane feature.
+          taxiway: Name shown in search results for an aeroway=taxiway feature.
+          terminal: Name shown in search results for an aeroway=terminal feature.
+          windsock: Name shown in search results for an aeroway=windsock feature.
+        amenity:
+          animal_boarding: Name shown in search results for an amenity=animal_boarding feature.
+          animal_shelter: Name shown in search results for an amenity=animal_shelter feature.
+          arts_centre: Name shown in search results for an amenity=arts_centre feature.
+          atm: Name shown in search results for an amenity=atm feature.
+          bank: Name shown in search results for an amenity=bank feature.
+          bar: Name shown in search results for an amenity=bar feature.
+          bbq: Name shown in search results for an amenity=bbq feature.
+          bench: Name shown in search results for an amenity=bench feature.
+          bicycle_parking: Name shown in search results for an amenity=bicycle_parking feature.
+          bicycle_rental: Name shown in search results for an amenity=bicycle_rental feature.
+          bicycle_repair_station: Name shown in search results for an amenity=bicycle_repair_station feature.
+          biergarten: Name shown in search results for an amenity=biergarten feature.
+          blood_bank: Name shown in search results for an amenity=blood_bank feature.
+          boat_rental: Name shown in search results for an amenity=boat_rental feature.
+          brothel: Name shown in search results for an amenity=brothel feature.
+          bureau_de_change: Name shown in search results for an amenity=bureau_de_change feature.
+          bus_station: Name shown in search results for an amenity=bus_station feature.
+          cafe: Name shown in search results for an amenity=cafe feature.
+          car_rental: Name shown in search results for an amenity=car_rental feature.
+          car_sharing: Name shown in search results for an amenity=car_sharing feature.
+          car_wash: Name shown in search results for an amenity=car_wash feature.
+          casino: Name shown in search results for an amenity=casino feature.
+          charging_station: Name shown in search results for an amenity=charging_station feature.
+          childcare: Name shown in search results for an amenity=childcare feature.
+          cinema: Name shown in search results for an amenity=cinema feature.
+          clinic: Name shown in search results for an amenity=clinic feature.
+          clock: Name shown in search results for an amenity=clock feature.
+          college: Name shown in search results for an amenity=college feature.
+          community_centre: Name shown in search results for an amenity=community_centre feature.
+          conference_centre: Name shown in search results for an amenity=conference_centre feature.
+          courthouse: Name shown in search results for an amenity=courthouse feature.
+          crematorium: Name shown in search results for an amenity=crematorium feature.
+          dentist: Name shown in search results for an amenity=dentist feature.
+          doctors: Name shown in search results for an amenity=doctors feature.
+          drinking_water: Name shown in search results for an amenity=drinking_water feature.
+          driving_school: Name shown in search results for an amenity=driving_school feature.
+          embassy: Name shown in search results for an amenity=embassy feature.
+          events_venue: Name shown in search results for an amenity=events_venue feature.
+          fast_food: Name shown in search results for an amenity=fast_food feature.
+          ferry_terminal: Name shown in search results for an amenity=ferry_terminal feature.
+          fire_station: Name shown in search results for an amenity=fire_station feature.
+          food_court: Name shown in search results for an amenity=food_court feature.
+          fountain: Name shown in search results for an amenity=fountain feature.
+          fuel: Name shown in search results for an amenity=fuel feature.
+          gambling: Name shown in search results for an amenity=gambling feature.
+          grave_yard: Name shown in search results for an amenity=grave_yard feature.
+          grit_bin: Name shown in search results for an amenity=grit_bin feature.
+          hospital: Name shown in search results for an amenity=hospital feature.
+          hunting_stand: Name shown in search results for an amenity=hunting_stand feature.
+          ice_cream: Name shown in search results for an amenity=ice_cream feature.
+          internet_cafe: Name shown in search results for an amenity=internet_cafe feature.
+          kindergarten: Name shown in search results for an amenity=kindergarten feature.
+          language_school: Name shown in search results for an amenity=language_school feature.
+          library: Name shown in search results for an amenity=library feature.
+          loading_dock: Name shown in search results for an amenity=loading_dock feature.
+          love_hotel: Name shown in search results for an amenity=love_hotel feature.
+          marketplace: Name shown in search results for an amenity=marketplace feature.
+          mobile_money_agent: Name shown in search results for an amenity=mobile_money_agent feature.
+          monastery: Name shown in search results for an amenity=monastery feature.
+          money_transfer: Name shown in search results for an amenity=money_transfer feature.
+          motorcycle_parking: Name shown in search results for an amenity=motorcycle_parking feature.
+          music_school: Name shown in search results for an amenity=music_school feature.
+          nightclub: Name shown in search results for an amenity=nightclub feature.
+          nursing_home: Name shown in search results for an amenity=nursing_home feature.
+          parking: Name shown in search results for an amenity=parking feature.
+          parking_entrance: Name shown in search results for an amenity=parking_entrance feature.
+          parking_space: Name shown in search results for an amenity=parking_space feature.
+          payment_terminal: Name shown in search results for an amenity=payment_terminal feature.
+          pharmacy: Name shown in search results for an amenity=pharmacy feature.
+          place_of_worship: Name shown in search results for an amenity=place_of_worship feature.
+          police: Name shown in search results for an amenity=police feature.
+          post_box: Name shown in search results for an amenity=post_box feature.
+          post_office: Name shown in search results for an amenity=post_office feature.
+          prison: Name shown in search results for an amenity=prison feature.
+          pub: Name shown in search results for an amenity=pub feature.
+          public_bath: Name shown in search results for an amenity=public_bath feature.
+          public_bookcase: Name shown in search results for an amenity=public_bookcase feature.
+          public_building: Name shown in search results for an amenity=public_building feature.
+          ranger_station: Name shown in search results for an amenity=ranger_station feature.
+          recycling: Name shown in search results for an amenity=recycling feature.
+          restaurant: Name shown in search results for an amenity=restaurant feature.
+          sanitary_dump_station: Name shown in search results for an amenity=sanitary_dump_station feature.
+          school: Name shown in search results for an amenity=school feature.
+          shelter: Name shown in search results for an amenity=shelter feature.
+          shower: Name shown in search results for an amenity=shower feature.
+          social_centre: Name shown in search results for an amenity=social_centre feature.
+          social_facility: Name shown in search results for an amenity=social_facility feature.
+          studio: Name shown in search results for an amenity=studio feature.
+          swimming_pool: Name shown in search results for an amenity=swimming_pool feature.
+          taxi: Name shown in search results for an amenity=taxi feature.
+          telephone: Name shown in search results for an amenity=telephone feature.
+          theatre: Name shown in search results for an amenity=theatre feature.
+          toilets: Name shown in search results for an amenity=toilets feature.
+          townhall: Name shown in search results for an amenity=townhall feature.
+          training: Name shown in search results for an amenity=training feature.
+          university: Name shown in search results for an amenity=university feature.
+          vehicle_inspection: Name shown in search results for an amenity=vehicle_inspection feature.
+          vending_machine: Name shown in search results for an amenity=vending_machine feature.
+          veterinary: Name shown in search results for an amenity=veterinary feature.
+          village_hall: Name shown in search results for an amenity=village_hall feature.
+          waste_basket: Name shown in search results for an amenity=waste_basket feature.
+          waste_disposal: Name shown in search results for an amenity=waste_disposal feature.
+          waste_dump_site: Name shown in search results for an amenity=waste_dump_site feature.
+          watering_place: Name shown in search results for an amenity=watering_place feature.
+          water_point: Name shown in search results for an amenity=water_point feature.
+          weighbridge: Name shown in search results for an amenity=weighbridge feature.
+          'yes': Name shown in search results for a generic amenity feature.
+        boundary:
+          aboriginal_lands: Name shown in search results for a boundary=aboriginal_lands feature.
+          administrative: Name shown in search results for a boundary=administrative feature.
+          census: Name shown in search results for a boundary=census feature.
+          national_park: Name shown in search results for a boundary=national_park feature.
+          political: Name shown in search results for a boundary=political feature.
+          protected_area: Name shown in search results for a boundary=protected_area feature.
+          'yes': Name shown in search results for a generic boundary feature.
+        bridge:
+          aqueduct: Name shown in search results for a bridge=aqueduct feature.
+          boardwalk: Name shown in search results for a bridge=boardwalk feature.
+          suspension: Name shown in search results for a bridge=suspension feature.
+          swing: Name shown in search results for a bridge=swing feature.
+          viaduct: Name shown in search results for a bridge=viaduct feature.
+          'yes': Name shown in search results for a generic bridge feature.
+        building:
+          apartment: Name shown in search results for a building=apartment feature.
+          apartments: Name shown in search results for a building=apartments feature.
+          barn: Name shown in search results for a building=barn feature.
+          bungalow: Name shown in search results for a building=bungalow feature.
+          cabin: Name shown in search results for a building=cabin feature.
+          chapel: Name shown in search results for a building=chapel feature.
+          church: Name shown in search results for a building=church feature.
+          civic: Name shown in search results for a building=civic feature.
+          college: Name shown in search results for a building=college feature.
+          commercial: Name shown in search results for a building=commercial feature.
+          construction: Name shown in search results for a building=construction feature.
+          cowshed: Name shown in search results for a building=cowshed feature.
+          detached: Name shown in search results for a building=detached feature.
+          dormitory: Name shown in search results for a building=dormitory feature.
+          duplex: Name shown in search results for a building=duplex feature.
+          farm: Name shown in search results for a building=farm feature.
+          farm_auxiliary: Name shown in search results for a building=farm_auxiliary feature.
+          garage: Name shown in search results for a building=garage feature.
+          garages: Name shown in search results for a building=garages feature.
+          greenhouse: Name shown in search results for a building=greenhouse feature.
+          hangar: Name shown in search results for a building=hangar feature.
+          hospital: Name shown in search results for a building=hospital feature.
+          hotel: Name shown in search results for a building=hotel feature.
+          house: Name shown in search results for a building=house feature.
+          houseboat: Name shown in search results for a building=houseboat feature.
+          hut: Name shown in search results for a building=hut feature.
+          industrial: Name shown in search results for a building=industrial feature.
+          kindergarten: Name shown in search results for a building=kindergarten feature.
+          manufacture: Name shown in search results for a building=manufacture feature.
+          office: Name shown in search results for a building=office feature.
+          public: Name shown in search results for a building=public feature.
+          residential: Name shown in search results for a building=residential feature.
+          retail: Name shown in search results for a building=retail feature.
+          roof: Name shown in search results for a building=roof feature.
+          ruins: Name shown in search results for a building=ruins feature.
+          school: Name shown in search results for a building=school feature.
+          semidetached_house: Name shown in search results for a building=semidetached_house feature.
+          service: Name shown in search results for a building=service feature.
+          shed: Name shown in search results for a building=shed feature.
+          stable: Name shown in search results for a building=stable feature.
+          static_caravan: Name shown in search results for a building=static_caravan feature.
+          sty: Name shown in search results for a building=sty feature.
+          temple: Name shown in search results for a building=temple feature.
+          terrace: Name shown in search results for a building=terrace feature.
+          train_station: Name shown in search results for a building=train_station feature.
+          university: Name shown in search results for a building=university feature.
+          warehouse: Name shown in search results for a building=warehouse feature.
+          'yes': Name shown in search results for a generic building feature.
+        club:
+          scout: Name shown in search results for a club=scout feature.
+          sport: Name shown in search results for a club=sport feature.
+          'yes': Name shown in search results for a generic club feature.
+        craft:
+          beekeeper: Name shown in search results for a craft=beekeeper feature.
+          blacksmith: Name shown in search results for a craft=blacksmith feature.
+          brewery: Name shown in search results for a craft=brewery feature.
+          carpenter: Name shown in search results for a craft=carpenter feature.
+          caterer: Name shown in search results for a craft=caterer feature.
+          confectionery: Name shown in search results for a craft=confectionery feature.
+          dressmaker: Name shown in search results for a craft=dressmaker feature.
+          electrician: Name shown in search results for a craft=electrician feature.
+          electronics_repair: Name shown in search results for a craft=electronics_repair feature.
+          gardener: Name shown in search results for a craft=gardener feature.
+          glaziery: Name shown in search results for a craft=glaziery feature.
+          handicraft: Name shown in search results for a craft=handicraft feature.
+          hvac: Name shown in search results for a craft=hvac feature.
+          metal_construction: Name shown in search results for a craft=metal_construction feature.
+          painter: Name shown in search results for a craft=painter feature.
+          photographer: Name shown in search results for a craft=photographer feature.
+          plumber: Name shown in search results for a craft=plumber feature.
+          roofer: Name shown in search results for a craft=roofer feature.
+          sawmill: Name shown in search results for a craft=sawmill feature.
+          shoemaker: Name shown in search results for a craft=shoemaker feature.
+          stonemason: Name shown in search results for a craft=stonemason feature.
+          tailor: Name shown in search results for a craft=tailor feature.
+          window_construction: Name shown in search results for a craft=window_construction feature.
+          winery: Name shown in search results for a craft=winery feature.
+          'yes': Name shown in search results for a generic craft feature.
+        emergency:
+          access_point: Name shown in search results for an emergency=access_point feature.
+          ambulance_station: Name shown in search results for an emergency=ambulance_station feature.
+          assembly_point: Name shown in search results for an emergency=assembly_point feature.
+          defibrillator: Name shown in search results for an emergency=defibrillator feature.
+          fire_extinguisher: Name shown in search results for an emergency=fire_extinguisher feature.
+          fire_water_pond: Name shown in search results for an emergency=fire_water_pond feature.
+          landing_site: Name shown in search results for an emergency=landing_site feature.
+          life_ring: Name shown in search results for an emergency=life_ring feature.
+          phone: Name shown in search results for an emergency=phone feature.
+          siren: Name shown in search results for an emergency=siren feature.
+          suction_point: Name shown in search results for an emergency=suction_point feature.
+          water_tank: Name shown in search results for an emergency=water_tank feature.
         highway:
-          trunk: '[[:w:Trunk road|Trunk roads]] are planned and managed at the national
-            level, distinguishing them from non-trunk roads which are managed by local
-            authorities.'
-          trunk_link: '[[:w:Trunk road|Trunk roads]] are planned and managed at the
-            national level, distinguishing them from non-trunk roads which are managed
-            by local authorities.'
+          abandoned: Name shown in search results for a highway=abandoned feature.
+          bridleway: Name shown in search results for a highway=bridleway feature.
+          bus_guideway: Name shown in search results for a highway=bus_guideway feature.
+          bus_stop: Name shown in search results for a highway=bus_stop feature.
+          busway: Name shown in search results for a highway=busway feature.
+          construction: Name shown in search results for a highway=construction feature.
+          corridor: Name shown in search results for a highway=corridor feature.
+          crossing: Name shown in search results for a highway=crossing feature.
+          cycleway: Name shown in search results for a highway=cycleway feature.
+          elevator: Name shown in search results for a highway=elevator feature.
+          emergency_access_point: Name shown in search results for a highway=emergency_access_point feature.
+          emergency_bay: Name shown in search results for a highway=emergency_bay feature.
+          footway: Name shown in search results for a highway=footway feature.
+          ford: Name shown in search results for a highway=ford feature.
+          give_way: Name shown in search results for a highway=give_way feature.
+          living_street: Name shown in search results for a highway=living_street feature.
+          milestone: Name shown in search results for a highway=milestone feature.
+          motorway: Name shown in search results for a highway=motorway feature.
+          motorway_junction: Name shown in search results for a highway=motorway_junction feature.
+          motorway_link: Name shown in search results for a highway=motorway_link feature.
+          passing_place: Name shown in search results for a highway=passing_place feature.
+          path: Name shown in search results for a highway=path feature.
+          pedestrian: Name shown in search results for a highway=pedestrian feature.
+          platform: Name shown in search results for a highway=platform feature.
+          primary: Name shown in search results for a highway=primary feature.
+          primary_link: Name shown in search results for a highway=primary_link feature.
+          proposed: Name shown in search results for a highway=proposed feature.
+          raceway: Name shown in search results for a highway=raceway feature.
+          residential: Name shown in search results for a highway=residential feature.
+          rest_area: Name shown in search results for a highway=rest_area feature.
+          road: Name shown in search results for a highway=road feature.
+          secondary: Name shown in search results for a highway=secondary feature.
+          secondary_link: Name shown in search results for a highway=secondary_link feature.
+          service: Name shown in search results for a highway=service feature.
+          services: Name shown in search results for a highway=services feature.
+          speed_camera: Name shown in search results for a highway=speed_camera feature.
+          steps: Name shown in search results for a highway=steps feature.
+          stop: Name shown in search results for a highway=stop feature.
+          street_lamp: Name shown in search results for a highway=street_lamp feature.
+          tertiary: Name shown in search results for a highway=tertiary feature.
+          tertiary_link: Name shown in search results for a highway=tertiary_link feature.
+          track: Name shown in search results for a highway=track feature.
+          traffic_mirror: Name shown in search results for a highway=traffic_mirror feature.
+          traffic_signals: Name shown in search results for a highway=traffic_signals feature.
+          trailhead: Name shown in search results for a highway=trailhead feature.
+          trunk: Name shown in search results for a highway=trunk feature.
+          trunk_link: Name shown in search results for a highway=trunk_link feature.
+          turning_circle: Name shown in search results for a highway=turning_circle feature.
+          turning_loop: Name shown in search results for a highway=turning_loop feature.
+          unclassified: Name shown in search results for a highway=unclassified feature.
+          'yes': Name shown in search results for a generic highway feature.
+        historic:
+          aircraft: Name shown in search results for a historic=aircraft feature.
+          archaeological_site: Name shown in search results for a historic=archaeological_site feature.
+          bomb_crater: Name shown in search results for a historic=bomb_crater feature.
+          battlefield: Name shown in search results for a historic=battlefield feature.
+          boundary_stone: Name shown in search results for a historic=boundary_stone feature.
+          building: Name shown in search results for a historic=building feature.
+          bunker: Name shown in search results for a historic=bunker feature.
+          cannon: Name shown in search results for a historic=cannon feature.
+          castle: Name shown in search results for a historic=castle feature.
+          charcoal_pile: Name shown in search results for a historic=charcoal_pile feature.
+          church: Name shown in search results for a historic=church feature.
+          city_gate: Name shown in search results for a historic=city_gate feature.
+          citywalls: Name shown in search results for a historic=citywalls feature.
+          fort: Name shown in search results for a historic=fort feature.
+          heritage: Name shown in search results for a historic=heritage feature.
+          hollow_way: Name shown in search results for a historic=hollow_way feature.
+          house: Name shown in search results for a historic=house feature.
+          manor: Name shown in search results for a historic=manor feature.
+          memorial: Name shown in search results for a historic=memorial feature.
+          milestone: Name shown in search results for a historic=milestone feature.
+          mine: Name shown in search results for a historic=mine feature.
+          mine_shaft: Name shown in search results for a historic=mine_shaft feature.
+          monument: Name shown in search results for a historic=monument feature.
+          railway: Name shown in search results for a historic=railway feature.
+          roman_road: Name shown in search results for a historic=roman_road feature.
+          ruins: Name shown in search results for a historic=ruins feature.
+          rune_stone: Name shown in search results for a historic=rune_stone feature.
+          stone: Name shown in search results for a historic=stone feature.
+          tomb: Name shown in search results for a historic=tomb feature.
+          tower: Name shown in search results for a historic=tower feature.
+          wayside_chapel: Name shown in search results for a historic=wayside_chapel feature.
+          wayside_cross: Name shown in search results for a historic=wayside_cross feature.
+          wayside_shrine: Name shown in search results for a historic=wayside_shrine feature.
+          wreck: Name shown in search results for a historic=wreck feature.
+          'yes': Name shown in search results for a generic historic feature.
+        information:
+          guidepost: Name shown in search results for an information=guidepost feature.
+          board: Name shown in search results for an information=board feature.
+          map: Name shown in search results for an information=map feature.
+          office: Name shown in search results for an information=office feature.
+          terminal: Name shown in search results for an information=terminal feature.
+          sign: Name shown in search results for an information=sign feature.
+          stele: Name shown in search results for an information=stele feature.
+        junction:
+          'yes': Name shown in search results for a generic junction feature.
+        landuse:
+          allotments: Name shown in search results for a landuse=allotments feature.
+          aquaculture: Name shown in search results for a landuse=aquaculture feature.
+          basin: Name shown in search results for a landuse=basin feature.
+          brownfield: Name shown in search results for a landuse=brownfield feature.
+          cemetery: Name shown in search results for a landuse=cemetery feature.
+          commercial: Name shown in search results for a landuse=commercial feature.
+          conservation: Name shown in search results for a landuse=conservation feature.
+          construction: Name shown in search results for a landuse=construction feature.
+          farmland: Name shown in search results for a landuse=farmland feature.
+          farmyard: Name shown in search results for a landuse=farmyard feature.
+          forest: Name shown in search results for a landuse=forest feature.
+          garages: Name shown in search results for a landuse=garages feature.
+          grass: Name shown in search results for a landuse=grass feature.
+          greenfield: Name shown in search results for a landuse=greenfield feature.
+          industrial: Name shown in search results for a landuse=industrial feature.
+          landfill: Name shown in search results for a landuse=landfill feature.
+          meadow: Name shown in search results for a landuse=meadow feature.
+          military: Name shown in search results for a landuse=military feature.
+          mine: Name shown in search results for a landuse=mine feature.
+          orchard: Name shown in search results for a landuse=orchard feature.
+          plant_nursery: Name shown in search results for a landuse=plant_nursery feature.
+          quarry: Name shown in search results for a landuse=quarry feature.
+          railway: Name shown in search results for a landuse=railway feature.
+          recreation_ground: Name shown in search results for a landuse=recreation_ground feature.
+          religious: Name shown in search results for a landuse=religious feature.
+          reservoir: Name shown in search results for a landuse=reservoir feature.
+          reservoir_watershed: Name shown in search results for a landuse=reservoir_watershed feature.
+          residential: Name shown in search results for a landuse=residential feature.
+          retail: Name shown in search results for a landuse=retail feature.
+          village_green: Name shown in search results for a landuse=village_green feature.
+          vineyard: Name shown in search results for a landuse=vineyard feature.
+          'yes': Name shown in search results for a generic landuse feature.
+        leisure:
+          adult_gaming_centre: Name shown in search results for a leisure=adult_gaming_centre feature.
+          amusement_arcade: Name shown in search results for a leisure=amusement_arcade feature.
+          bandstand: Name shown in search results for a leisure=bandstand feature.
+          beach_resort: Name shown in search results for a leisure=beach_resort feature.
+          bird_hide: Name shown in search results for a leisure=bird_hide feature.
+          bleachers: Name shown in search results for a leisure=bleachers feature.
+          bowling_alley: Name shown in search results for a leisure=bowling_alley feature.
+          common: Name shown in search results for a leisure=common feature.
+          dance: Name shown in search results for a leisure=dance feature.
+          dog_park: Name shown in search results for a leisure=dog_park feature.
+          firepit: Name shown in search results for a leisure=firepit feature.
+          fishing: Name shown in search results for a leisure=fishing feature.
+          fitness_centre: Name shown in search results for a leisure=fitness_centre feature.
+          fitness_station: Name shown in search results for a leisure=fitness_station feature.
+          garden: Name shown in search results for a leisure=garden feature.
+          golf_course: Name shown in search results for a leisure=golf_course feature.
+          horse_riding: Name shown in search results for a leisure=horse_riding feature.
+          ice_rink: Name shown in search results for a leisure=ice_rink feature.
+          marina: Name shown in search results for a leisure=marina feature.
+          miniature_golf: Name shown in search results for a leisure=miniature_golf feature.
+          nature_reserve: Name shown in search results for a leisure=nature_reserve feature.
+          outdoor_seating: Name shown in search results for a leisure=outdoor_seating feature.
+          park: Name shown in search results for a leisure=park feature.
+          picnic_table: Name shown in search results for a leisure=picnic_table feature.
+          pitch: Name shown in search results for a leisure=pitch feature.
+          playground: Name shown in search results for a leisure=playground feature.
+          recreation_ground: Name shown in search results for a leisure=recreation_ground feature.
+          resort: Name shown in search results for a leisure=resort feature.
+          sauna: Name shown in search results for a leisure=sauna feature.
+          slipway: Name shown in search results for a leisure=slipway feature.
+          sports_centre: Name shown in search results for a leisure=sports_centre feature.
+          stadium: Name shown in search results for a leisure=stadium feature.
+          swimming_pool: Name shown in search results for a leisure=swimming_pool feature.
+          track: Name shown in search results for a leisure=track feature.
+          water_park: Name shown in search results for a leisure=water_park feature.
+          'yes': Name shown in search results for a generic leisure feature.
         lock:
-          "yes": Refers to a [[:w:en:Lock (water navigation)|lock for ships]], not
-            a lock for closing doors.
+          'yes': Name shown in search results for a generic lock feature.
+        man_made:
+          adit: Name shown in search results for a man_made=adit feature.
+          advertising: Name shown in search results for a man_made=advertising feature.
+          antenna: Name shown in search results for a man_made=antenna feature.
+          avalanche_protection: Name shown in search results for a man_made=avalanche_protection feature.
+          beacon: Name shown in search results for a man_made=beacon feature.
+          beam: Name shown in search results for a man_made=beam feature.
+          beehive: Name shown in search results for a man_made=beehive feature.
+          breakwater: Name shown in search results for a man_made=breakwater feature.
+          bridge: Name shown in search results for a man_made=bridge feature.
+          bunker_silo: Name shown in search results for a man_made=bunker_silo feature.
+          cairn: Name shown in search results for a man_made=cairn feature.
+          chimney: Name shown in search results for a man_made=chimney feature.
+          clearcut: Name shown in search results for a man_made=clearcut feature.
+          communications_tower: Name shown in search results for a man_made=communications_tower feature.
+          crane: Name shown in search results for a man_made=crane feature.
+          cross: Name shown in search results for a man_made=cross feature.
+          dolphin: Name shown in search results for a man_made=dolphin feature.
+          dyke: Name shown in search results for a man_made=dyke feature.
+          embankment: Name shown in search results for a man_made=embankment feature.
+          flagpole: Name shown in search results for a man_made=flagpole feature.
+          gasometer: Name shown in search results for a man_made=gasometer feature.
+          groyne: Name shown in search results for a man_made=groyne feature.
+          kiln: Name shown in search results for a man_made=kiln feature.
+          lighthouse: Name shown in search results for a man_made=lighthouse feature.
+          manhole: Name shown in search results for a man_made=manhole feature.
+          mast: Name shown in search results for a man_made=mast feature.
+          mine: Name shown in search results for a man_made=mine feature.
+          mineshaft: Name shown in search results for a man_made=mineshaft feature.
+          monitoring_station: Name shown in search results for a man_made=monitoring_station feature.
+          petroleum_well: Name shown in search results for a man_made=petroleum_well feature.
+          pier: Name shown in search results for a man_made=pier feature.
+          pipeline: Name shown in search results for a man_made=pipeline feature.
+          pumping_station: Name shown in search results for a man_made=pumping_station feature.
+          reservoir_covered: Name shown in search results for a man_made=reservoir_covered feature.
+          silo: Name shown in search results for a man_made=silo feature.
+          snow_cannon: Name shown in search results for a man_made=snow_cannon feature.
+          snow_fence: Name shown in search results for a man_made=snow_fence feature.
+          storage_tank: Name shown in search results for a man_made=storage_tank feature.
+          street_cabinet: Name shown in search results for a man_made=street_cabinet feature.
+          surveillance: Name shown in search results for a man_made=surveillance feature.
+          telescope: Name shown in search results for a man_made=telescope feature.
+          tower: Name shown in search results for a man_made=tower feature.
+          utility_pole: Name shown in search results for a man_made=utility_pole feature.
+          wastewater_plant: Name shown in search results for a man_made=wastewater_plant feature.
+          watermill: Name shown in search results for a man_made=watermill feature.
+          water_tap: Name shown in search results for a man_made=water_tap feature.
+          water_tower: Name shown in search results for a man_made=water_tower feature.
+          water_well: Name shown in search results for a man_made=water_well feature.
+          water_works: Name shown in search results for a man_made=water_works feature.
+          windmill: Name shown in search results for a man_made=windmill feature.
+          works: Name shown in search results for a man_made=works feature.
+          'yes': Name shown in search results for a generic man_made feature.
+        military:
+          airfield: Name shown in search results for a military=airfield feature.
+          barracks: Name shown in search results for a military=barracks feature.
+          bunker: Name shown in search results for a military=bunker feature.
+          checkpoint: Name shown in search results for a military=checkpoint feature.
+          trench: Name shown in search results for a military=trench feature.
+          'yes': Name shown in search results for a generic military feature.
+        mountain_pass:
+          'yes': Name shown in search results for a generic mountain_pass feature.
+        natural:
+          atoll: Name shown in search results for a natural=atoll feature.
+          bare_rock: Name shown in search results for a natural=bare_rock feature.
+          bay: Name shown in search results for a natural=bay feature.
+          beach: Name shown in search results for a natural=beach feature.
+          cape: Name shown in search results for a natural=cape feature.
+          cave_entrance: Name shown in search results for a natural=cave_entrance feature.
+          cliff: Name shown in search results for a natural=cliff feature.
+          coastline: Name shown in search results for a natural=coastline feature.
+          crater: Name shown in search results for a natural=crater feature.
+          dune: Name shown in search results for a natural=dune feature.
+          fell: Name shown in search results for a natural=fell feature.
+          fjord: Name shown in search results for a natural=fjord feature.
+          forest: Name shown in search results for a natural=forest feature.
+          geyser: Name shown in search results for a natural=geyser feature.
+          glacier: Name shown in search results for a natural=glacier feature.
+          grassland: Name shown in search results for a natural=grassland feature.
+          heath: Name shown in search results for a natural=heath feature.
+          hill: Name shown in search results for a natural=hill feature.
+          hot_spring: Name shown in search results for a natural=hot_spring feature.
+          island: Name shown in search results for a natural=island feature.
+          isthmus: Name shown in search results for a natural=isthmus feature.
+          land: Name shown in search results for a natural=land feature.
+          marsh: Name shown in search results for a natural=marsh feature.
+          moor: Name shown in search results for a natural=moor feature.
+          mud: Name shown in search results for a natural=mud feature.
+          peak: Name shown in search results for a natural=peak feature.
+          peninsula: Name shown in search results for a natural=peninsula feature.
+          point: Name shown in search results for a natural=point feature.
+          reef: Name shown in search results for a natural=reef feature.
+          ridge: Name shown in search results for a natural=ridge feature.
+          rock: Name shown in search results for a natural=rock feature.
+          saddle: Name shown in search results for a natural=saddle feature.
+          sand: Name shown in search results for a natural=sand feature.
+          scree: Name shown in search results for a natural=scree feature.
+          scrub: Name shown in search results for a natural=scrub feature.
+          shingle: Name shown in search results for a natural=shingle feature.
+          spring: Name shown in search results for a natural=spring feature.
+          stone: Name shown in search results for a natural=stone feature.
+          strait: Name shown in search results for a natural=strait feature.
+          tree: Name shown in search results for a natural=tree feature.
+          tree_row: Name shown in search results for a natural=tree_row feature.
+          tundra: Name shown in search results for a natural=tundra feature.
+          valley: Name shown in search results for a natural=valley feature.
+          volcano: Name shown in search results for a natural=volcano feature.
+          water: Name shown in search results for a natural=water feature.
+          wetland: Name shown in search results for a natural=wetland feature.
+          wood: Name shown in search results for a natural=wood feature.
+          'yes': Name shown in search results for a generic natural feature.
+        office:
+          accountant: Name shown in search results for an office=accountant feature.
+          administrative: Name shown in search results for an office=administrative feature.
+          advertising_agency: Name shown in search results for an office=advertising_agency feature.
+          architect: Name shown in search results for an office=architect feature.
+          association: Name shown in search results for an office=association feature.
+          company: Name shown in search results for an office=company feature.
+          diplomatic: Name shown in search results for an office=diplomatic feature.
+          educational_institution: Name shown in search results for an office=educational_institution feature.
+          employment_agency: Name shown in search results for an office=employment_agency feature.
+          energy_supplier: Name shown in search results for an office=energy_supplier feature.
+          estate_agent: Name shown in search results for an office=estate_agent feature.
+          financial: Name shown in search results for an office=financial feature.
+          government: Name shown in search results for an office=government feature.
+          insurance: Name shown in search results for an office=insurance feature.
+          it: Name shown in search results for an office=it feature.
+          lawyer: Name shown in search results for an office=lawyer feature.
+          logistics: Name shown in search results for an office=logistics feature.
+          newspaper: Name shown in search results for an office=newspaper feature.
+          ngo: Name shown in search results for an office=ngo feature.
+          notary: Name shown in search results for an office=notary feature.
+          religion: Name shown in search results for an office=religion feature.
+          research: Name shown in search results for an office=research feature.
+          tax_advisor: Name shown in search results for an office=tax_advisor feature.
+          telecommunication: Name shown in search results for an office=telecommunication feature.
+          travel_agent: Name shown in search results for an office=travel_agent feature.
+          'yes': Name shown in search results for a generic office feature.
+        place:
+          allotments: Name shown in search results for a place=allotments feature.
+          archipelago: Name shown in search results for a place=archipelago feature.
+          city: Name shown in search results for a place=city feature.
+          city_block: Name shown in search results for a place=city_block feature.
+          country: Name shown in search results for a place=country feature.
+          county: Name shown in search results for a place=county feature.
+          farm: Name shown in search results for a place=farm feature.
+          hamlet: Name shown in search results for a place=hamlet feature.
+          house: Name shown in search results for a place=house feature.
+          houses: Name shown in search results for a place=houses feature.
+          island: Name shown in search results for a place=island feature.
+          islet: Name shown in search results for a place=islet feature.
+          isolated_dwelling: Name shown in search results for a place=isolated_dwelling feature.
+          locality: Name shown in search results for a place=locality feature.
+          municipality: Name shown in search results for a place=municipality feature.
+          neighbourhood: Name shown in search results for a place=neighbourhood feature.
+          plot: Name shown in search results for a place=plot feature.
+          postcode: Name shown in search results for a place=postcode feature.
+          quarter: Name shown in search results for a place=quarter feature.
+          region: Name shown in search results for a place=region feature.
+          sea: Name shown in search results for a place=sea feature.
+          square: Name shown in search results for a place=square feature.
+          state: Name shown in search results for a place=state feature.
+          subdivision: Name shown in search results for a place=subdivision feature.
+          suburb: Name shown in search results for a place=suburb feature.
+          town: Name shown in search results for a place=town feature.
+          village: Name shown in search results for a place=village feature.
+          'yes': Name shown in search results for a generic place feature.
+        railway:
+          abandoned: Name shown in search results for a railway=abandoned feature.
+          buffer_stop: Name shown in search results for a railway=buffer_stop feature.
+          construction: Name shown in search results for a railway=construction feature.
+          disused: Name shown in search results for a railway=disused feature.
+          funicular: Name shown in search results for a railway=funicular feature.
+          halt: Name shown in search results for a railway=halt feature.
+          junction: Name shown in search results for a railway=junction feature.
+          level_crossing: Name shown in search results for a railway=level_crossing feature.
+          light_rail: Name shown in search results for a railway=light_rail feature.
+          miniature: Name shown in search results for a railway=miniature feature.
+          monorail: Name shown in search results for a railway=monorail feature.
+          narrow_gauge: Name shown in search results for a railway=narrow_gauge feature.
+          platform: Name shown in search results for a railway=platform feature.
+          preserved: Name shown in search results for a railway=preserved feature.
+          proposed: Name shown in search results for a railway=proposed feature.
+          rail: Name shown in search results for a railway=rail feature.
+          spur: Name shown in search results for a railway=spur feature.
+          station: Name shown in search results for a railway=station feature.
+          stop: Name shown in search results for a railway=stop feature.
+          subway: Name shown in search results for a railway=subway feature.
+          subway_entrance: Name shown in search results for a railway=subway_entrance feature.
+          switch: Name shown in search results for a railway=switch feature.
+          tram: Name shown in search results for a railway=tram feature.
+          tram_stop: Name shown in search results for a railway=tram_stop feature.
+          turntable: Name shown in search results for a railway=turntable feature.
+          yard: Name shown in search results for a railway=yard feature.
+        shop:
+          agrarian: Name shown in search results for a shop=agrarian feature.
+          alcohol: Name shown in search results for a shop=alcohol feature.
+          antiques: Name shown in search results for a shop=antiques feature.
+          appliance: Name shown in search results for a shop=appliance feature.
+          art: Name shown in search results for a shop=art feature.
+          baby_goods: Name shown in search results for a shop=baby_goods feature.
+          bag: Name shown in search results for a shop=bag feature.
+          bakery: Name shown in search results for a shop=bakery feature.
+          bathroom_furnishing: Name shown in search results for a shop=bathroom_furnishing feature.
+          beauty: Name shown in search results for a shop=beauty feature.
+          bed: Name shown in search results for a shop=bed feature.
+          beverages: Name shown in search results for a shop=beverages feature.
+          bicycle: Name shown in search results for a shop=bicycle feature.
+          bookmaker: Name shown in search results for a shop=bookmaker feature.
+          books: Name shown in search results for a shop=books feature.
+          boutique: Name shown in search results for a shop=boutique feature.
+          butcher: Name shown in search results for a shop=butcher feature.
+          car: Name shown in search results for a shop=car feature.
+          car_parts: Name shown in search results for a shop=car_parts feature.
+          car_repair: Name shown in search results for a shop=car_repair feature.
+          carpet: Name shown in search results for a shop=carpet feature.
+          charity: Name shown in search results for a shop=charity feature.
+          cheese: Name shown in search results for a shop=cheese feature.
+          chemist: Name shown in search results for a shop=chemist feature.
+          chocolate: Name shown in search results for a shop=chocolate feature.
+          clothes: Name shown in search results for a shop=clothes feature.
+          coffee: Name shown in search results for a shop=coffee feature.
+          computer: Name shown in search results for a shop=computer feature.
+          confectionery: Name shown in search results for a shop=confectionery feature.
+          convenience: Name shown in search results for a shop=convenience feature.
+          copyshop: Name shown in search results for a shop=copyshop feature.
+          cosmetics: Name shown in search results for a shop=cosmetics feature.
+          craft: Name shown in search results for a shop=craft feature.
+          curtain: Name shown in search results for a shop=curtain feature.
+          dairy: Name shown in search results for a shop=dairy feature.
+          deli: Name shown in search results for a shop=deli feature.
+          department_store: Name shown in search results for a shop=department_store feature.
+          discount: Name shown in search results for a shop=discount feature.
+          doityourself: Name shown in search results for a shop=doityourself feature.
+          dry_cleaning: Name shown in search results for a shop=dry_cleaning feature.
+          e-cigarette: Name shown in search results for a shop=e-cigarette feature.
+          electronics: Name shown in search results for a shop=electronics feature.
+          erotic: Name shown in search results for a shop=erotic feature.
+          estate_agent: Name shown in search results for a shop=estate_agent feature.
+          fabric: Name shown in search results for a shop=fabric feature.
+          farm: Name shown in search results for a shop=farm feature.
+          fashion: Name shown in search results for a shop=fashion feature.
+          fishing: Name shown in search results for a shop=fishing feature.
+          florist: Name shown in search results for a shop=florist feature.
+          food: Name shown in search results for a shop=food feature.
+          frame: Name shown in search results for a shop=frame feature.
+          funeral_directors: Name shown in search results for a shop=funeral_directors feature.
+          furniture: Name shown in search results for a shop=furniture feature.
+          garden_centre: Name shown in search results for a shop=garden_centre feature.
+          gas: Name shown in search results for a shop=gas feature.
+          general: Name shown in search results for a shop=general feature.
+          gift: Name shown in search results for a shop=gift feature.
+          greengrocer: Name shown in search results for a shop=greengrocer feature.
+          grocery: Name shown in search results for a shop=grocery feature.
+          hairdresser: Name shown in search results for a shop=hairdresser feature.
+          hardware: Name shown in search results for a shop=hardware feature.
+          health_food: Name shown in search results for a shop=health_food feature.
+          hearing_aids: Name shown in search results for a shop=hearing_aids feature.
+          herbalist: Name shown in search results for a shop=herbalist feature.
+          hifi: Name shown in search results for a shop=hifi feature.
+          houseware: Name shown in search results for a shop=houseware feature.
+          ice_cream: Name shown in search results for a shop=ice_cream feature.
+          interior_decoration: Name shown in search results for a shop=interior_decoration feature.
+          jewelry: Name shown in search results for a shop=jewelry feature.
+          kiosk: Name shown in search results for a shop=kiosk feature.
+          kitchen: Name shown in search results for a shop=kitchen feature.
+          laundry: Name shown in search results for a shop=laundry feature.
+          locksmith: Name shown in search results for a shop=locksmith feature.
+          lottery: Name shown in search results for a shop=lottery feature.
+          mall: Name shown in search results for a shop=mall feature.
+          massage: Name shown in search results for a shop=massage feature.
+          medical_supply: Name shown in search results for a shop=medical_supply feature.
+          mobile_phone: Name shown in search results for a shop=mobile_phone feature.
+          money_lender: Name shown in search results for a shop=money_lender feature.
+          motorcycle: Name shown in search results for a shop=motorcycle feature.
+          motorcycle_repair: Name shown in search results for a shop=motorcycle_repair feature.
+          music: Name shown in search results for a shop=music feature.
+          musical_instrument: Name shown in search results for a shop=musical_instrument feature.
+          newsagent: Name shown in search results for a shop=newsagent feature.
+          nutrition_supplements: Name shown in search results for a shop=nutrition_supplements feature.
+          optician: Name shown in search results for a shop=optician feature.
+          organic: Name shown in search results for a shop=organic feature.
+          outdoor: Name shown in search results for a shop=outdoor feature.
+          paint: Name shown in search results for a shop=paint feature.
+          pastry: Name shown in search results for a shop=pastry feature.
+          pawnbroker: Name shown in search results for a shop=pawnbroker feature.
+          perfumery: Name shown in search results for a shop=perfumery feature.
+          pet: Name shown in search results for a shop=pet feature.
+          pet_grooming: Name shown in search results for a shop=pet_grooming feature.
+          photo: Name shown in search results for a shop=photo feature.
+          seafood: Name shown in search results for a shop=seafood feature.
+          second_hand: Name shown in search results for a shop=second_hand feature.
+          sewing: Name shown in search results for a shop=sewing feature.
+          shoes: Name shown in search results for a shop=shoes feature.
+          sports: Name shown in search results for a shop=sports feature.
+          stationery: Name shown in search results for a shop=stationery feature.
+          storage_rental: Name shown in search results for a shop=storage_rental feature.
+          supermarket: Name shown in search results for a shop=supermarket feature.
+          tailor: Name shown in search results for a shop=tailor feature.
+          tattoo: Name shown in search results for a shop=tattoo feature.
+          tea: Name shown in search results for a shop=tea feature.
+          ticket: Name shown in search results for a shop=ticket feature.
+          tobacco: Name shown in search results for a shop=tobacco feature.
+          toys: Name shown in search results for a shop=toys feature.
+          travel_agency: Name shown in search results for a shop=travel_agency feature.
+          tyres: Name shown in search results for a shop=tyres feature.
+          vacant: Name shown in search results for a shop=vacant feature.
+          variety_store: Name shown in search results for a shop=variety_store feature.
+          video: Name shown in search results for a shop=video feature.
+          video_games: Name shown in search results for a shop=video_games feature.
+          wholesale: Name shown in search results for a shop=wholesale feature.
+          wine: Name shown in search results for a shop=wine feature.
+          'yes': Name shown in search results for a generic shop feature.
+        tourism:
+          alpine_hut: Name shown in search results for a tourism=alpine_hut feature.
+          apartment: Name shown in search results for a tourism=apartment feature.
+          artwork: Name shown in search results for a tourism=artwork feature.
+          attraction: Name shown in search results for a tourism=attraction feature.
+          bed_and_breakfast: Name shown in search results for a tourism=bed_and_breakfast feature.
+          cabin: Name shown in search results for a tourism=cabin feature.
+          camp_pitch: Name shown in search results for a tourism=camp_pitch feature.
+          camp_site: Name shown in search results for a tourism=camp_site feature.
+          caravan_site: Name shown in search results for a tourism=caravan_site feature.
+          chalet: Name shown in search results for a tourism=chalet feature.
+          gallery: Name shown in search results for a tourism=gallery feature.
+          guest_house: Name shown in search results for a tourism=guest_house feature.
+          hostel: Name shown in search results for a tourism=hostel feature.
+          hotel: Name shown in search results for a tourism=hotel feature.
+          information: Name shown in search results for a tourism=information feature.
+          motel: Name shown in search results for a tourism=motel feature.
+          museum: Name shown in search results for a tourism=museum feature.
+          picnic_site: Name shown in search results for a tourism=picnic_site feature.
+          theme_park: Name shown in search results for a tourism=theme_park feature.
+          viewpoint: Name shown in search results for a tourism=viewpoint feature.
+          wilderness_hut: Name shown in search results for a tourism=wilderness_hut feature.
+          zoo: Name shown in search results for a tourism=zoo feature.
+        tunnel:
+          building_passage: Name shown in search results for a tunnel=building_passage feature.
+          culvert: Name shown in search results for a tunnel=culvert feature.
+          'yes': Name shown in search results for a generic tunnel feature.
+        water:
+          lake: Name shown in search results for a water=lake feature.
+          pond: Name shown in search results for a water=pond feature.
+          reservoir: Name shown in search results for a water=reservoir feature.
+          basin: Name shown in search results for a water=basin feature.
+          fishpond: Name shown in search results for a water=fishpond feature.
+          lagoon: Name shown in search results for a water=lagoon feature.
+          wastewater: Name shown in search results for a water=wastewater feature.
+          oxbow: Name shown in search results for a water=oxbow feature.
+          stream_pool: Name shown in search results for a water=stream_pool feature.
+          lock: Name shown in search results for a water=lock feature.
+        waterway:
+          artificial: Name shown in search results for a waterway=artificial feature.
+          boatyard: Name shown in search results for a waterway=boatyard feature.
+          canal: Name shown in search results for a waterway=canal feature.
+          dam: Name shown in search results for a waterway=dam feature.
+          derelict_canal: Name shown in search results for a waterway=derelict_canal feature.
+          ditch: Name shown in search results for a waterway=ditch feature.
+          dock: Name shown in search results for a waterway=dock feature.
+          drain: Name shown in search results for a waterway=drain feature.
+          lock: Name shown in search results for a waterway=lock feature.
+          lock_gate: Name shown in search results for a waterway=lock_gate feature.
+          mooring: Name shown in search results for a waterway=mooring feature.
+          rapids: Name shown in search results for a waterway=rapids feature.
+          river: Name shown in search results for a waterway=river feature.
+          stream: Name shown in search results for a waterway=stream feature.
+          wadi: Name shown in search results for a waterway=wadi feature.
+          waterfall: Name shown in search results for a waterway=waterfall feature.
+          weir: Name shown in search results for a waterway=weir feature.
+          'yes': Name shown in search results for a generic waterway feature.
+      admin_levels:
+        level2: Label for an international boundary (admin_level=2) in Nominatim search results.
+        level3: Label for an administrative boundary at level 3 in Nominatim search results.
+        level4: Label for an administrative boundary at level 4 in Nominatim search results.
+        level5: Label for an administrative boundary at level 5 in Nominatim search results.
+        level6: Label for an administrative boundary at level 6 in Nominatim search results.
+        level7: Label for an administrative boundary at level 7 in Nominatim search results.
+        level8: Label for an administrative boundary at level 8 in Nominatim search results.
+        level9: Label for an administrative boundary at level 9 in Nominatim search results.
+        level10: Label for an administrative boundary at level 10 in Nominatim search results.
+        level11: Label for an administrative boundary at level 11 in Nominatim search results.
       border_types:
-        occupation: The boundary of a region occupied by an occupying force, not a
-          professional occupation.
-        possession: The boundary of a territorial possession.
-        ward: '[[:w:Ward (electoral subdivision)]]'
+        archdiocese: Name shown in search results for a border_type=archdiocese boundary.
+        arrondissement: Name shown in search results for a border_type=arrondissement boundary.
+        audiencia: Name shown in search results for a border_type=audiencia boundary.
+        borough: Name shown in search results for a border_type=borough boundary.
+        caliphate: Name shown in search results for a border_type=caliphate boundary.
+        canton: Name shown in search results for a border_type=canton boundary.
+        captaincy_general: Name shown in search results for a border_type=captaincy_general boundary.
+        census_area: Name shown in search results for a border_type=census_area boundary.
+        cercle: Name shown in search results for a border_type=cercle boundary.
+        chiefdom: Name shown in search results for a border_type=chiefdom boundary.
+        city: Name shown in search results for a border_type=city boundary.
+        city-state: Name shown in search results for a border_type=city-state boundary.
+        colony: Name shown in search results for a border_type=colony boundary.
+        comarca: Name shown in search results for a border_type=comarca boundary.
+        commonwealth: Name shown in search results for a border_type=commonwealth boundary.
+        commune: Name shown in search results for a border_type=commune boundary.
+        condominium: Name shown in search results for a border_type=condominium boundary.
+        confederation: Name shown in search results for a border_type=confederation boundary.
+        county: Name shown in search results for a border_type=county boundary.
+        departement: Name shown in search results for a border_type=departement boundary.
+        department: Name shown in search results for a border_type=department boundary.
+        diocese: Name shown in search results for a border_type=diocese boundary.
+        district: Name shown in search results for a border_type=district boundary.
+        distrito: Name shown in search results for a border_type=distrito boundary.
+        dominion: Name shown in search results for a border_type=dominion boundary.
+        emirate: Name shown in search results for a border_type=emirate boundary.
+        empire: Name shown in search results for a border_type=empire boundary.
+        eyalet: Name shown in search results for a border_type=eyalet boundary.
+        federal_district: Name shown in search results for a border_type=federal_district boundary.
+        federation: Name shown in search results for a border_type=federation boundary.
+        freguesia: Name shown in search results for a border_type=freguesia boundary.
+        ghetto: Name shown in search results for a border_type=ghetto boundary.
+        governorate: Name shown in search results for a border_type=governorate boundary.
+        hundred: Name shown in search results for a border_type=hundred boundary.
+        intendancy: Name shown in search results for a border_type=intendancy boundary.
+        kingdom: Name shown in search results for a border_type=kingdom boundary.
+        local_authority: Name shown in search results for a border_type=local_authority boundary.
+        major_division: Name shown in search results for a border_type=major_division boundary.
+        markaz: Name shown in search results for a border_type=markaz boundary.
+        municipality: Name shown in search results for a border_type=municipality boundary.
+        municipi: Name shown in search results for a border_type=municipi boundary.
+        município: Name shown in search results for a border_type=município boundary.
+        nation: Name shown in search results for a border_type=nation boundary.
+        national: Name shown in search results for a border_type=national boundary.
+        neighbourhood: Name shown in search results for a border_type=neighbourhood boundary.
+        oblast: Name shown in search results for a border_type=oblast boundary.
+        occupation: Name shown in search results for a border_type=occupation boundary. This refers to a territory under military or political occupation.
+        overseas_collectivity: Name shown in search results for a border_type=overseas_collectivity boundary.
+        overseas_department: Name shown in search results for a border_type=overseas_department boundary.
+        overseas_territory: Name shown in search results for a border_type=overseas_territory boundary.
+        parish: Name shown in search results for a border_type=parish boundary.
+        planning_region: Name shown in search results for a border_type=planning_region boundary.
+        possession: Name shown in search results for a border_type=possession boundary. This refers to a territory held as a possession.
+        prefecture: Name shown in search results for a border_type=prefecture boundary.
+        prefecture_apostolic: Name shown in search results for a border_type=prefecture_apostolic boundary.
+        principate: Name shown in search results for a border_type=principate boundary.
+        protectorate: Name shown in search results for a border_type=protectorate boundary.
+        province: Name shown in search results for a border_type=province boundary.
+        rancho: Name shown in search results for a border_type=rancho boundary.
+        realm: Name shown in search results for a border_type=realm boundary.
+        região: Name shown in search results for a border_type=região boundary.
+        region: Name shown in search results for a border_type=region boundary.
+        reichsgau: Name shown in search results for a border_type=reichsgau boundary.
+        republic: Name shown in search results for a border_type=republic boundary.
+        rode: Name shown in search results for a border_type=rode boundary.
+        sanjak: Name shown in search results for a border_type=sanjak boundary.
+        sector: Name shown in search results for a border_type=sector boundary.
+        shire: Name shown in search results for a border_type=shire boundary.
+        state: Name shown in search results for a border_type=state boundary.
+        subdistrict: Name shown in search results for a border_type=subdistrict boundary.
+        sultanate: Name shown in search results for a border_type=sultanate boundary.
+        territory: Name shown in search results for a border_type=territory boundary.
+        territorial_prelature: Name shown in search results for a border_type=territorial_prelature boundary.
+        town: Name shown in search results for a border_type=town boundary.
+        township: Name shown in search results for a border_type=township boundary.
+        vicariate_apostolic: Name shown in search results for a border_type=vicariate_apostolic boundary.
+        viceroyalty: Name shown in search results for a border_type=viceroyalty boundary.
+        village: Name shown in search results for a border_type=village boundary.
+        viyalet: Name shown in search results for a border_type=viyalet boundary.
+        voivodeship: Name shown in search results for a border_type=voivodeship boundary.
+        ward: Name shown in search results for a border_type=ward boundary.
+        zone: Name shown in search results for a border_type=zone boundary.
+  searches:
+    show:
+      title:
+        latlon: Title for search results from the internal lat/lon search provider.
+        nominatim: Title for search results from the Nominatim geocoder.
+        nominatim_reverse: Title for search results from the Nominatim reverse geocoder.
+    queries:
+      create:
+        no_results: Message shown when a search query returns no results.
+        more_results: Link text to load more search results.
+  directions:
+    show:
+      title: Page title for the directions view.
+      distance: Label for the total route distance in the directions panel.
+      time: Label for the estimated travel time in the directions panel.
+      ascend: Label for the total ascent (uphill elevation gain) of a route.
+      descend: Label for the total descent (downhill elevation loss) of a route.
+      kilometers: Distance unit label for kilometers.
+      miles_feet: Distance unit label for miles and feet.
+      miles_yards: Distance unit label for miles and yards.
+      distance_units_settings: Link text to the user's distance units preference settings.
+      download: Link text to download the route as a GeoJSON file.
+      filename: Default filename (without extension) for the downloaded route file.
+      directions_courtesy_html: Credit line for the routing service. %{link} is the service name as a hyperlink.
+      check_demo_html: Link to the routing service's own website for more details. %{link} is the service name as a hyperlink.
+  issues:
+    index:
+      title: Page title for the issues list.
+      select_status: Placeholder label for the status filter dropdown on the issues list.
+      select_type: Placeholder label for the type filter dropdown on the issues list.
+      select_last_managed_by: Placeholder label for the 'last managed by' filter dropdown on the issues list.
+      reported_user: Label for the reported user filter field on the issues list.
+      not_managed: Label for issues that have not yet been managed by a moderator.
+      search: Button label to submit the issues search/filter form.
+      search_guidance: Label above the issues search input field.
+      states:
+        ignored: Status label for an issue that has been ignored by a moderator.
+        open: Status label for an issue that is currently open.
+        resolved: Status label for an issue that has been resolved.
+    page:
+      user_not_found: Message shown when the searched user does not exist.
+      issues_not_found: Message shown when no issues match the search criteria.
+      reported_user: Column header for the reported user in the issues table.
+      status: Column header for the issue status in the issues table.
+      reports: Column header for the number of reports in the issues table.
+      last_updated: Column header for the date the issue was last updated.
+      last_managed: Column header for the date the issue was last managed by a moderator.
+      reporting_users: Column header for the users who reported the issue.
+      reports_count:
+        one: Singular count of reports on an issue. %{count} is the number.
+        other: Plural count of reports on an issue. %{count} is the number.
+      reported_item: Column header for the item that was reported.
+      states:
+        ignored: Status label for an ignored issue in the issues table.
+        open: Status label for an open issue in the issues table.
+        resolved: Status label for a resolved issue in the issues table.
+    resolve:
+      resolved: Flash message shown after a moderator resolves an issue.
+    ignore:
+      ignored: Flash message shown after a moderator ignores an issue.
+    reopen:
+      reopened: Flash message shown after a moderator reopens an issue.
+    comments:
+      comment_from_html: Attribution line for a comment on an issue. %{user_link} is the commenter's name as a link, %{comment_created_at} is the date.
+      reassign_to_moderators: Button label to reassign an issue to the moderators team.
+      reassign_to_administrators: Button label to reassign an issue to the administrators team.
+    reports:
+      reported_by_html: Attribution line for a report. %{category} is the report category, %{user} is the reporter's name, %{updated_at} is the date.
+    helper:
+      reportable_title:
+        diary_comment: Title for a reported diary comment. %{entry_title} is the diary entry title, %{comment_id} is the comment ID number.
+        note: Title for a reported map note. %{note_id} is the note ID number.
+      reportable_heading:
+        diary_comment_html: Heading for a reported diary comment showing creation and update dates. %{title} is the comment title, %{datetime_created} and %{datetime_updated} are timestamps.
+        diary_entry_html: Heading for a reported diary entry showing creation and update dates. %{title} is the entry title, %{datetime_created} and %{datetime_updated} are timestamps.
+        note_html: Heading for a reported map note showing creation and update dates. %{title} is the note title, %{datetime_created} and %{datetime_updated} are timestamps.
+        user_html: Heading for a reported user showing creation date. %{title} is the username, %{datetime_created} is the timestamp.
+    reporters:
+      index:
+        title: Page title for the list of reporters for a specific issue. %{issue_id} is the issue ID number.
+      reporters:
+        more_reporters: Text indicating there are additional reporters not shown. %{count} is the number of additional reporters.
+    show:
+      title:
+        open: Page title for an open issue. %{issue_id} is the issue ID number.
+        ignored: Page title for an ignored issue. %{issue_id} is the issue ID number.
+        resolved: Page title for a resolved issue. %{issue_id} is the issue ID number.
+      reports:
+        one: Singular count of reports on the issue detail page. %{count} is the number.
+        other: Plural count of reports on the issue detail page. %{count} is the number.
+      no_reports: Message shown when an issue has no reports.
+      report_created_at_html: Timestamp for when the issue was first reported. %{datetime} is the date and time.
+      last_resolved_at_html: Timestamp for when the issue was last resolved. %{datetime} is the date and time.
+      last_updated_at_html: Timestamp for when the issue was last updated. %{datetime} is the date and time, %{displayname} is the moderator's name.
+      resolve: Button label to resolve an issue.
+      ignore: Button label to ignore an issue.
+      reopen: Button label to reopen an issue.
+      reports_of_this_issue: Section heading for the list of reports on an issue.
+      read_reports: Section heading for reports that have already been read.
+      new_reports: Section heading for new, unread reports.
+      other_issues_against_this_user: Section heading for other issues filed against the same user.
+      no_other_issues: Message shown when there are no other issues against the reported user.
+      comments_on_this_issue: Section heading for moderator comments on an issue.
+      comment_from_html: Attribution line for a moderator comment on an issue. %{user_link} is the commenter's name as a link, %{comment_created_at} is the date.
+      reassign_to_moderators: Button label to reassign the issue to the moderators team.
+      reassign_to_administrators: Button label to reassign the issue to the administrators team.
+  issue_comments:
+    create:
+      comment_created: Flash message shown after a moderator comment is successfully created.
+      issue_reassigned: Flash message shown after a comment is created and the issue is reassigned.
+  reports:
+    new:
+      title_html: Page title for the report submission form. %{link} is the reported item as a hyperlink.
+      disclaimer:
+        intro: Introductory text for the report disclaimer checklist.
+        not_just_mistake: Disclaimer checklist item asking the reporter to confirm the problem is not a mistake.
+        unable_to_fix: Disclaimer checklist item asking the reporter to confirm they cannot fix the problem themselves.
+        resolve_with_user: Disclaimer checklist item asking the reporter to confirm they tried to resolve the issue with the user.
+      categories:
+        diary_entry:
+          spam_label: Report category label for a diary entry that is or contains spam.
+          offensive_label: Report category label for a diary entry that is obscene or offensive.
+          threat_label: Report category label for a diary entry that contains a threat.
+          other_label: Report category label for other issues with a diary entry.
+        diary_comment:
+          spam_label: Report category label for a diary comment that is or contains spam.
+          offensive_label: Report category label for a diary comment that is obscene or offensive.
+          threat_label: Report category label for a diary comment that contains a threat.
+          other_label: Report category label for other issues with a diary comment.
+        user:
+          spam_label: Report category label for a user profile that is or contains spam.
+          offensive_label: Report category label for a user profile that is obscene or offensive.
+          threat_label: Report category label for a user profile that contains a threat.
+          vandal_label: Report category label for a user who is vandalizing the map.
+          other_label: Report category label for other issues with a user.
+        note:
+          spam_label: Report category label for a map note that is spam.
+          personal_label: Report category label for a map note that contains personal data.
+          abusive_label: Report category label for a map note that is abusive.
+          other_label: Report category label for other issues with a map note.
+    create:
+      successful_report: Flash message shown after a report is successfully submitted.
+      provide_details: Flash message shown when the reporter did not fill in required details.
+  languages_panes:
+    select_language_list:
+      search_language: Placeholder text in the language search box in the language selector panel.
+      languages:
+        af: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Afrikaans language."
+        gsw: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Alemannic language."
+        frp: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Arpitan language."
+        ast: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Asturian language."
+        az: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Azerbaijani language."
+        id: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Indonesian language."
+        ms: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Malay language."
+        bcl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Central Bikol language."
+        bs: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Bosnian language."
+        br: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Breton language."
+        ca: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Catalan language."
+        cs: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Czech language."
+        cy: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Welsh language."
+        da: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Danish language."
+        de: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the German language."
+        dsb: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Lower Sorbian language."
+        et: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Estonian language."
+        en: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the English language."
+        en-GB: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the British English language variant."
+        es: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Spanish language."
+        eo: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Esperanto language."
+        eu: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Basque language."
+        fr: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the French language."
+        fy: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Western Frisian language."
+        fur: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Friulian language."
+        ga: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Irish language."
+        gd: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Scottish Gaelic language."
+        gl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Galician language."
+        aln: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Gheg Albanian language."
+        hsb: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Upper Sorbian language."
+        hr: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Croatian language."
+        ia: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Interlingua language."
+        is: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Icelandic language."
+        it: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Italian language."
+        kw: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Cornish language."
+        gcf: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Guadeloupean Creole language."
+        ku-Latn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Kurdish language in Latin script."
+        lv: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Latvian language."
+        lb: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Luxembourgish language."
+        lkt: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Lakota language."
+        lt: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Lithuanian language."
+        hu: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Hungarian language."
+        fit: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Tornedalen Finnish language."
+        nl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Dutch language."
+        nb: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Norwegian Bokmål language."
+        nn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Norwegian Nynorsk language."
+        oc: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Occitan language."
+        nds: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Low German language."
+        pl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Polish language."
+        pt-PT: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Portuguese (Portugal) language variant."
+        pt: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Portuguese (Brazil) language variant."
+        ksh: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Colognian language."
+        ro: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Romanian language."
+        sc: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Sardinian language."
+        sco: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Scots language."
+        sq: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Albanian language."
+        scn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Sicilian language."
+        sk: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Slovak language."
+        sl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Slovenian language."
+        sr-Latn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Serbian language in Latin script."
+        sh: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Serbo-Croatian language in Latin script."
+        fi: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Finnish language."
+        sv: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Swedish language."
+        tl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Tagalog language."
+        kab: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Kabyle language."
+        vi: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Vietnamese language."
+        tr: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Turkish language."
+        yo: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Yoruba language."
+        diq: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Dimli language."
+        el: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Greek language."
+        ba: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Bashkir language."
+        be: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Belarusian language."
+        be-Tarask: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Belarusian language in Taraškievica orthography."
+        bg: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Bulgarian language."
+        mk: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Macedonian language."
+        mo: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Moldovan language."
+        ce: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Chechen language."
+        ru: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Russian language."
+        sr: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Serbian language in Cyrillic script."
+        tt: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Tatar language in Cyrillic script."
+        uk: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Ukrainian language."
+        kk-cyrl: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Kazakh language in Cyrillic script."
+        yi: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Yiddish language."
+        he: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Hebrew language."
+        ar: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Arabic language."
+        skr-arab: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Saraiki language."
+        fa: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Persian language."
+        arz: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Egyptian Arabic language."
+        pnb: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Western Punjabi language."
+        ps: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Pashto language."
+        nqo: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the N'Ko language."
+        ne: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Nepali language."
+        mr: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Marathi language."
+        hi: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Hindi language."
+        bn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Bangla language."
+        pa: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Punjabi language."
+        gu: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Gujarati language."
+        ta: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Tamil language."
+        te: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Telugu language."
+        kn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Kannada language."
+        th: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Thai language."
+        my: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Burmese language."
+        shn: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Shan language."
+        xmf: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Mingrelian language."
+        ka: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Georgian language."
+        km: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Khmer language."
+        sat: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Santali language."
+        zh-CN: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Simplified Chinese language variant."
+        zh-TW: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Traditional Chinese language variant (Taiwan)."
+        zh-HK: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Traditional Chinese language variant (Hong Kong)."
+        ja: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Japanese language."
+        ko: "{{doc-important|Do not translate. This is the English name of the language used in the language selector.}} Name of the Korean language."
   layouts:
     project_name:
-      title: |-
-        {{Optional}}
-        {{Identical|OpenHistoricalMap}}
-      h1: |-
-        {{Optional}}
-        {{Identical|OpenHistoricalMap}}
-    partners_devseed: See https://developmentseed.org/
-    partners_greeninfo: See https://www.greeninfo.org/
-    tou: '{{Identical|Requestaccount-page}}'
+      title: The project name as it appears in the browser tab/window title. Do not translate 'OpenHistoricalMap'.
+      h1: The project name as it appears in the main page heading. Do not translate 'OpenHistoricalMap'.
+    logo:
+      alt_text: Alt text for the OpenHistoricalMap logo image in the site header.
+    main_navigation: Accessible label for the main navigation landmark.
+    layer_info: Tooltip or label for the layer information button on the map.
+    home: Tooltip for the button that pans the map to the user's home location.
+    logout: Navigation link text to log out of the site.
+    log_in: Navigation link text to log in to the site.
+    sign_up: Navigation link text to create a new account.
+    start_mapping: Navigation link text to start editing the map.
+    edit: Navigation link text to open the map editor.
+    history: Navigation link text to view the map edit history.
+    export: Navigation link text to export map data.
+    issues: Navigation link text to view the moderation issues list (shown to moderators/admins only).
+    gps_traces: Navigation link text to view GPS traces.
+    user_diaries: Navigation link text to view user diary entries.
+    edit_with: Navigation link text to edit with a specific editor. %{editor} is the editor name.
+    tag_line: Short tagline describing the project, shown on the homepage.
+    intro_header: Heading for the introductory text shown to logged-out users on the homepage.
+    intro_text: Introductory paragraph describing the project, shown to logged-out users on the homepage.
+    intro_2_create_account: Link text in the homepage introduction to create a new account.
+    partners_title: Heading for the partners section in the site footer.
+    hosting_partners_2024_html: Text crediting the project's hosting and organizational partners. %{osmus}, %{osmf}, %{greeninfo}, and %{devseed} are partner names as hyperlinks.
+    partners_devseed: Name of the Development Seed partner organization, used as link text.
+    partners_greeninfo: Name of the GreenInfo Network partner organization, used as link text.
+    partners_osmf: Name of the OpenStreetMap Foundation partner organization, used as link text.
+    partners_osmus: Name of the OpenStreetMap U.S. partner organization, used as link text.
+    welcome_tou_notice_html: Notice shown to users about agreeing to the Terms of Use by using the site. %{terms_link} is the Terms of Use as a hyperlink.
+    terms_of_use: Link text for the Terms of Use, used in the welcome notice.
+    tou: Abbreviation or short name for the Terms of Use, used in various contexts.
+    nothing_to_preview: Message shown in the preview pane when there is no content to preview.
+    help: Navigation link text to the help page.
+    about: Navigation link text to the about page.
+    copyright: Navigation link text to the copyright page.
+    communities: Navigation link text to the communities page.
+    learn_more: Link text to learn more about the project.
+    more: Label for the 'more' dropdown menu in the navigation bar.
+    header:
+      about: Header navigation link to the about page.
+      communities: Header navigation link to the communities page.
+      copyright: Header navigation link to the copyright page.
+      donate: Header navigation link to the donation page.
+      edit: Header navigation link to open the map editor.
+      edit_with: Header navigation link to edit with a specific editor. %{editor} is the editor name.
+      export: Header navigation link to export map data.
+      gps_traces: Header navigation link to GPS traces.
+      help: Header navigation link to the help page.
+      history: Header navigation link to the edit history.
+      home: Header navigation link/button to go to the user's home location.
+      issues: Header navigation link to the issues list (shown to moderators/admins only).
+      log_out: Header navigation link to log out.
+      log_in: Header navigation link to log in.
+      more: Label for the 'more' dropdown in the header navigation.
+      select_language: Label for the language selector button in the header.
+      sign_up: Header navigation link to sign up for a new account.
+      user_diaries: Header navigation link to user diaries.
+    meta:
+      openstreetmap_search: Name of the OpenHistoricalMap search engine, used in browser search engine registration.
+    select_language_button:
+      title: Tooltip for the language selector button in the header.
+    offline_flash:
+      osm_offline: Flash message shown when the database is completely offline for maintenance.
+      osm_read_only: Flash message shown when the database is in read-only mode for maintenance.
+      expected_restore_html: Message indicating when services are expected to be restored. %{time} is the estimated restoration time.
+      announcement: Link text to read the maintenance announcement.
   user_mailer:
+    diary_comment_notification:
+      description: Subject line used in the RSS/Atom feed for a diary comment notification email. %{id} is the diary entry ID.
+      subject: Email subject for a diary comment notification. %{user} is the commenter's username.
+      hi: Salutation in the diary comment notification email. %{to_user} is the recipient's username.
+      header: Opening line of the diary comment notification email (plain text). %{from_user} is the commenter, %{subject} is the diary entry title.
+      header_html: Opening line of the diary comment notification email (HTML). %{from_user} is the commenter, %{subject} is the diary entry title.
+      footer: Footer of the diary comment notification email (plain text) with links to read, comment, and reply. %{readurl}, %{commenturl}, %{replyurl} are URLs.
+      footer_html: Footer of the diary comment notification email (HTML) with links to read, comment, and reply. %{readurl}, %{commenturl}, %{replyurl} are URLs.
+      footer_unsubscribe: Unsubscribe line in the diary comment notification email (plain text). %{unsubscribeurl} is the unsubscribe URL.
+      footer_unsubscribe_html: Unsubscribe line in the diary comment notification email (HTML). %{unsubscribeurl} is the unsubscribe URL.
     message_notification:
-      hi: '{{Identical|Hi}}'
+      subject: Email subject for a private message notification. %{message_title} is the message subject.
+      hi: Salutation in the message notification email. %{to_user} is the recipient's username.
+      header: Opening line of the message notification email (plain text). %{from_user} is the sender, %{subject} is the message subject.
+      header_html: Opening line of the message notification email (HTML). %{from_user} is the sender, %{subject} is the message subject.
+      footer: Footer of the message notification email (plain text) with links to read and reply. %{readurl} and %{replyurl} are URLs.
+      footer_html: Footer of the message notification email (HTML) with links to read and reply. %{readurl} and %{replyurl} are URLs.
     follow_notification:
-      hi: '{{Identical|Hi}}'
+      hi: Salutation in the follow notification email. %{to_user} is the recipient's username.
+      subject: Email subject for a new follower notification. %{user} is the follower's username.
+      followed_you: Body text of the follow notification email. %{user} is the follower's username.
+      see_their_profile: Line in the follow notification email with a link to the follower's profile (plain text). %{userurl} is the URL.
+      see_their_profile_html: Line in the follow notification email with a link to the follower's profile (HTML). %{userurl} is the URL.
+      follow_them: Line in the follow notification email with a link to follow back (plain text). %{followurl} is the URL.
+      follow_them_html: Line in the follow notification email with a link to follow back (HTML). %{followurl} is the URL.
+    gpx_details:
+      details: Heading for the GPS trace details section in import notification emails.
+      filename: Label for the filename field in the GPS trace details.
+      url: Label for the URL field in the GPS trace details.
+      description: Label for the description field in the GPS trace details.
+      tags: Label for the tags field in the GPS trace details.
+      total_points: Label for the total number of GPS points in the trace details.
+      imported_points: Label for the number of successfully imported GPS points in the trace details.
     gpx_failure:
-      hi: '{{Identical|Hi}}'
+      hi: Salutation in the GPS trace import failure email. %{to_user} is the recipient's username.
+      failed_to_import: Opening line of the GPS trace import failure email.
+      verify: Instructions in the GPS trace import failure email asking the user to verify their file format.
+      more_info: Line in the GPS trace import failure email with a link to more information (plain text). %{url} is the URL.
+      more_info_html: Line in the GPS trace import failure email with a link to more information (HTML). %{url} is the URL.
+      import_failures_url: URL for the wiki page about GPS import failures, used in the failure notification email.
+      subject: Email subject for a GPS trace import failure notification.
     gpx_success:
-      hi: '{{Identical|Hi}}'
+      hi: Salutation in the GPS trace import success email. %{to_user} is the recipient's username.
+      imported_successfully: Opening line of the GPS trace import success email.
+      all_your_traces: Line in the GPS trace import success email with a link to all traces (plain text). %{url} is the URL.
+      all_your_traces_html: Line in the GPS trace import success email with a link to all traces (HTML). %{url} is the URL.
+      subject: Email subject for a GPS trace import success notification.
+    signup_confirm:
+      subject: Email subject for the account signup confirmation email.
+      greeting: Greeting line in the signup confirmation email.
+      created: Line in the signup confirmation email confirming account creation. %{site_url} is the site URL.
+      confirm: Instructions in the signup confirmation email asking the user to click the confirmation link.
+      welcome: Line in the signup confirmation email explaining what happens after confirmation.
+    email_confirm:
+      subject: Email subject for the email address change confirmation email.
+      greeting: Greeting line in the email address change confirmation email.
+      hopefully_you: Opening line of the email address change confirmation email. %{server_url} is the site URL, %{new_address} is the new email address.
+      click_the_link: Instructions in the email address change confirmation email.
+    lost_password:
+      subject: Email subject for the password reset request email.
+      greeting: Greeting line in the password reset email.
+      hopefully_you: Opening line of the password reset email.
+      click_the_link: Instructions in the password reset email asking the user to click the reset link.
+    note_comment_notification:
+      description: Subject line used in the RSS/Atom feed for a note comment notification email. %{id} is the note ID.
+      anonymous: Name used for anonymous users in note comment notification emails.
+      greeting: Greeting line in note comment notification emails.
+      commented:
+        subject_own: Email subject when someone comments on the recipient's own note. %{commenter} is the commenter's username.
+        subject_other: Email subject when someone comments on a note the recipient is subscribed to. %{commenter} is the commenter's username.
+        your_note: Body text when someone comments on the recipient's own note (plain text). %{commenter} is the commenter, %{place} is the location.
+        your_note_html: Body text when someone comments on the recipient's own note (HTML). %{commenter} is the commenter, %{place} is the location.
+        commented_note: Body text when someone comments on a note the recipient commented on (plain text). %{commenter} is the commenter, %{place} is the location.
+        commented_note_html: Body text when someone comments on a note the recipient commented on (HTML). %{commenter} is the commenter, %{place} is the location.
+      closed:
+        subject_own: Email subject when someone resolves the recipient's own note. %{commenter} is the resolver's username.
+        subject_other: Email subject when someone resolves a note the recipient is subscribed to. %{commenter} is the resolver's username.
+        your_note: Body text when someone resolves the recipient's own note (plain text). %{commenter} is the resolver, %{place} is the location.
+        your_note_html: Body text when someone resolves the recipient's own note (HTML). %{commenter} is the resolver, %{place} is the location.
+        commented_note: Body text when someone resolves a note the recipient commented on (plain text). %{commenter} is the resolver, %{place} is the location.
+        commented_note_html: Body text when someone resolves a note the recipient commented on (HTML). %{commenter} is the resolver, %{place} is the location.
+      reopened:
+        subject_own: Email subject when someone reactivates the recipient's own note. %{commenter} is the user's username.
+        subject_other: Email subject when someone reactivates a note the recipient is subscribed to. %{commenter} is the user's username.
+        your_note: Body text when someone reactivates the recipient's own note (plain text). %{commenter} is the user, %{place} is the location.
+        your_note_html: Body text when someone reactivates the recipient's own note (HTML). %{commenter} is the user, %{place} is the location.
+        commented_note: Body text when someone reactivates a note the recipient commented on (plain text). %{commenter} is the user, %{place} is the location.
+        commented_note_html: Body text when someone reactivates a note the recipient commented on (HTML). %{commenter} is the user, %{place} is the location.
+      details: Line in note comment notification emails with a link to the note (plain text). %{url} is the URL.
+      details_html: Line in note comment notification emails with a link to the note (HTML). %{url} is the URL.
+    changeset_comment_notification:
+      description: Subject line used in the RSS/Atom feed for a changeset comment notification email. %{id} is the changeset ID.
+      hi: Salutation in the changeset comment notification email. %{to_user} is the recipient's username.
+      commented:
+        subject_own: Email subject when someone comments on the recipient's own changeset. %{commenter} is the commenter's username.
+        subject_other: Email subject when someone comments on a changeset the recipient is subscribed to. %{commenter} is the commenter's username.
+        your_changeset: Body text when someone comments on the recipient's own changeset (plain text). %{commenter} is the commenter, %{time} is the timestamp.
+        your_changeset_html: Body text when someone comments on the recipient's own changeset (HTML). %{commenter} is the commenter, %{time} is the timestamp.
+        commented_changeset: Body text when someone comments on a changeset the recipient is watching (plain text). %{commenter} is the commenter, %{time} is the timestamp, %{changeset_author} is the changeset author.
+        commented_changeset_html: Body text when someone comments on a changeset the recipient is watching (HTML). %{commenter} is the commenter, %{time} is the timestamp, %{changeset_author} is the changeset author.
+        partial_changeset_with_comment: Partial sentence appended to changeset notification body when the changeset has a comment. %{changeset_comment} is the comment text.
+        partial_changeset_with_comment_html: Partial sentence appended to changeset notification body (HTML) when the changeset has a comment. %{changeset_comment} is the comment text.
+        partial_changeset_without_comment: Partial sentence appended to changeset notification body when the changeset has no comment.
+      details: Line in changeset comment notification emails with a link to the changeset (plain text). %{url} is the URL.
+      details_html: Line in changeset comment notification emails with a link to the changeset (HTML). %{url} is the URL.
+      unsubscribe: Line in changeset comment notification emails with an unsubscribe link (plain text). %{url} is the URL.
+      unsubscribe_html: Line in changeset comment notification emails with an unsubscribe link (HTML). %{url} is the URL.
+  confirmations:
+    confirm:
+      heading: Heading on the account confirmation page.
+      introduction_1: First paragraph on the account confirmation page explaining that a confirmation email was sent.
+      introduction_2: Second paragraph on the account confirmation page explaining how to confirm.
+      press confirm button: Instructions on the account confirmation page to press the confirm button.
+      button: Button label to confirm the account.
+      success: Flash message shown after successfully confirming an account.
+      already active: Flash message shown when trying to confirm an account that is already confirmed.
+      unknown token: Flash message shown when the confirmation token is invalid or expired.
+      if_need_resend: Text on the confirmation page offering to resend the confirmation email.
+      resend_button: Button label to resend the confirmation email.
+    confirm_resend:
+      failure: Flash message shown when the user to resend confirmation to cannot be found. %{name} is the username.
+    confirm_email:
+      heading: Heading on the email address change confirmation page.
+      press confirm button: Instructions on the email change confirmation page to press the confirm button.
+      button: Button label to confirm the email address change.
+      success: Flash message shown after successfully confirming an email address change.
+      failure: Flash message shown when the email address has already been confirmed with this token.
+      unknown_token: Flash message shown when the email confirmation token is invalid or expired.
+    resend_success_flash:
+      confirmation_sent: Flash message shown after successfully resending the confirmation email. %{email} is the email address.
+      whitelist: Additional flash message advising the user to whitelist the sender address. %{sender} is the sender email address.
+    gravatar:
+      disabled: Flash message shown after disabling Gravatar display.
+      enabled: Flash message shown after enabling Gravatar display.
+  messages:
+    new:
+      title: Page title for the compose new message page.
+      send_message_to_html: Heading on the compose message page. %{name} is the recipient's name as a link.
+      back_to_inbox: Link text to go back to the inbox from the compose message page.
+    create:
+      message_sent: Flash message shown after a message is successfully sent.
+      limit_exceeded: Flash message shown when the user has sent too many messages recently.
+    no_such_message:
+      title: Page title when a message cannot be found.
+      heading: Heading when a message cannot be found.
+      body: Body text when a message cannot be found.
+    show:
+      title: Page title for reading a message.
+      reply_button: Button label to reply to a message.
+      unread_button: Button label to mark a message as unread.
+      destroy_button: Button label to delete a message.
+      back: Link text to go back from the message view.
+      wrong_user: Error message shown when the logged-in user tries to read a message not addressed to them. %{user} is the current username.
+    destroy:
+      destroyed: Flash message shown after a message is deleted.
+    read_marks:
+      create:
+        notice: Flash message shown after marking a message as read.
+      destroy:
+        notice: Flash message shown after marking a message as unread.
+    mutes:
+      destroy:
+        notice: Flash message shown after moving a muted message back to the inbox.
+        error: Flash message shown when a muted message could not be moved to the inbox.
+    mailboxes:
+      heading:
+        my_inbox: Heading for the user's inbox.
+        my_outbox: Heading for the user's outbox.
+        muted_messages: Heading for the muted messages folder.
+      messages_table:
+        from: Column header for the sender in the messages table.
+        to: Column header for the recipient in the messages table.
+        subject: Column header for the message subject in the messages table.
+        date: Column header for the message date in the messages table.
+        actions: Column header for message actions in the messages table.
+      message:
+        unread_button: Button label to mark a message as unread in the messages table.
+        read_button: Button label to mark a message as read in the messages table.
+        destroy_button: Button label to delete a message in the messages table.
+        unmute_button: Button label to move a muted message back to the inbox.
+    inboxes:
+      show:
+        title: Page title for the inbox.
+        messages: Summary line showing the number of new and old messages. %{new_messages} and %{old_messages} are formatted counts.
+        new_messages:
+          one: Singular count of new messages in the inbox. %{count} is the number.
+          other: Plural count of new messages in the inbox. %{count} is the number.
+        old_messages:
+          one: Singular count of old (read) messages in the inbox. %{count} is the number.
+          other: Plural count of old (read) messages in the inbox. %{count} is the number.
+        no_messages_yet_html: Message shown when the inbox is empty. %{people_mapping_nearby_link} is a link to nearby mappers.
+        people_mapping_nearby: Link text for the 'people mapping nearby' link in the empty inbox message.
+    muted_inboxes:
+      show:
+        title: Page title for the muted messages folder.
+        messages:
+          one: Singular count of muted messages. %{count} is the number.
+          other: Plural count of muted messages. %{count} is the number.
+    outboxes:
+      show:
+        title: Page title for the outbox.
+        messages:
+          one: Singular count of sent messages in the outbox. %{count} is the number.
+          other: Plural count of sent messages in the outbox. %{count} is the number.
+        no_sent_messages_html: Message shown when the outbox is empty. %{people_mapping_nearby_link} is a link to nearby mappers.
+        people_mapping_nearby: Link text for the 'people mapping nearby' link in the empty outbox message.
+      message:
+        destroy_button: Button label to delete a sent message in the outbox.
+    replies:
+      new:
+        wrong_user: Error message shown when the logged-in user tries to reply to a message not addressed to them. %{user} is the current username.
+  passwords:
+    new:
+      title: Page title for the lost password / forgotten password page.
+      heading: Heading on the forgotten password page.
+      email address: Label for the email address input on the forgotten password page.
+      new password button: Button label to submit the password reset request.
+      help_text: Help text on the forgotten password page explaining what to enter.
+    create:
+      send_paranoid_instructions: Flash message shown after submitting a password reset request, regardless of whether the email exists (paranoid mode).
+    edit:
+      title: Page title for the password reset page.
+      heading: Heading on the password reset page. %{user} is the username.
+      reset: Button label to submit the new password on the reset page.
+      flash token bad: Flash message shown when the password reset token is invalid or not found.
+    update:
+      flash changed: Flash message shown after successfully changing the password.
+      flash token bad: Flash message shown when the password reset token is invalid during the update.
+  preferences:
+    preferences:
+      update:
+        failure: Flash message shown when preferences could not be updated.
+      update_success_flash:
+        message: Flash message shown after preferences are successfully updated.
+      navigation:
+        preferences: Navigation link label for the basic preferences section.
+        notification_preferences: Navigation link label for the notification preferences section.
+        advanced_preferences: Navigation link label for the advanced preferences section.
+    basic_preferences:
+      show:
+        title: Page title for the basic preferences page.
+        preferred_language: Label for the preferred language selector on the preferences page.
+        preferred_site_color_scheme: Label for the website color scheme preference.
+        site_color_schemes:
+          auto: Option label for automatic color scheme (follows system setting).
+          light: Option label for the light color scheme.
+          dark: Option label for the dark color scheme.
+        preferred_map_color_scheme: Label for the map color scheme preference.
+        map_color_schemes:
+          auto: Option label for automatic map color scheme.
+          light: Option label for the light map color scheme.
+          dark: Option label for the dark map color scheme.
+        preferred_editor_color_scheme: Label for the editor color scheme preference.
+        editor_color_schemes:
+          auto: Option label for the editor color scheme that matches the website setting.
+          light: Option label for the light editor color scheme.
+          dark: Option label for the dark editor color scheme.
+        save: Button label to save the basic preferences.
+    notification_preferences:
+      show:
+        title: Page title for the notification preferences page.
+        changeset_comment: Label for the changeset comment notification preference.
+        diary_comment: Label for the diary comment notification preference.
+        direct_message: Label for the direct message notification preference.
+        gpx_import_failure: Label for the GPS trace import failure notification preference.
+        gpx_import_success: Label for the GPS trace import success notification preference.
+        new_follower: Label for the new follower notification preference.
+        note_comment: Label for the note comment notification preference.
+        save: Button label to save the notification preferences.
+        delivery_mechanisms:
+          email: Label for the email delivery mechanism option in notification preferences.
+    advanced_preferences:
+      show:
+        title: Page title for the advanced preferences page.
+        save: Button label to save the advanced preferences.
+  profiles:
+    profile_sections:
+      navigation:
+        description: Navigation link label for the profile description section.
+        links: Navigation link label for the profile social links section.
+        image: Navigation link label for the profile image section.
+        company: Navigation link label for the profile company section.
+        location: Navigation link label for the profile location section.
+        contribution_calendar: Navigation link label for the contribution calendar configuration section.
+    descriptions:
+      show:
+        title: Page title for the profile description edit page.
+        save: Button label to save the profile description.
+        cancel: Button label to cancel editing the profile description.
+      update:
+        success: Flash message shown after successfully updating the profile description.
+        failure: Flash message shown when the profile description could not be updated.
+    links:
+      show:
+        title: Page title for the profile links edit page.
+        save: Button label to save the profile links.
+        cancel: Button label to cancel editing the profile links.
+        social_links:
+          title: Section heading for the social profile links on the profile links edit page.
+          remove: Button label to remove a social profile link.
+          add: Button label to add a new social profile link.
+      update:
+        success: Flash message shown after successfully updating the profile links.
+        failure: Flash message shown when the profile links could not be updated.
+    images:
+      show:
+        title: Page title for the profile image edit page.
+        save: Button label to save the profile image.
+        cancel: Button label to cancel editing the profile image.
+        gravatar:
+          gravatar: Label for the option to use a Gravatar as the profile image.
+          link: URL for the wiki page explaining what Gravatar is.
+          what_is_gravatar: Link text for the 'What is Gravatar?' link.
+        new image: Label for the option to upload a new profile image.
+        keep image: Label for the option to keep the current profile image.
+        delete image: Label for the option to remove the current profile image.
+        replace image: Label for the option to replace the current profile image.
+        image size hint: Hint text about the recommended image size for profile images.
+      update:
+        success: Flash message shown after successfully updating the profile image.
+        failure: Flash message shown when the profile image could not be updated.
+    companies:
+      show:
+        title: Page title for the profile company edit page.
+        save: Button label to save the profile company.
+        cancel: Button label to cancel editing the profile company.
+      update:
+        success: Flash message shown after successfully updating the profile company.
+        failure: Flash message shown when the profile company could not be updated.
+    locations:
+      show:
+        title: Page title for the profile location edit page.
+        save: Button label to save the profile location.
+        cancel: Button label to cancel editing the profile location.
+        no home location: Message shown when the user has not set a home location.
+        update home location on click: Checkbox label to update the home location when clicking on the map.
+        show: Button label to show the current home location on the map.
+        delete: Button label to delete the home location.
+        undelete: Button label to undo deleting the home location.
+      update:
+        success: Flash message shown after successfully updating the profile location.
+        failure: Flash message shown when the profile location could not be updated.
+    heatmaps:
+      show:
+        title: Page title for the contribution calendar configuration page.
+        show_contribution_calendar_in_public: Checkbox label to show the contribution calendar on the public profile page.
+        save: Button label to save the contribution calendar configuration.
+        cancel: Button label to cancel editing the contribution calendar configuration.
+      update:
+        success: Flash message shown after successfully updating the contribution calendar configuration.
+        failure: Flash message shown when the contribution calendar configuration could not be updated.
+  sessions:
+    new:
+      tab_title: Browser tab title for the login page.
+      login_to_authorize_html: Message shown when logging in to authorize a third-party application. %{client_app_name} is the application name.
+      already_logged_in_html: Message shown when the user is already logged in. %{user} is the current username as a link.
+      access_another_page: Message shown when the user was redirected to the login page from another page.
+      visit_referring_page: Button label to visit the page the user was trying to access before being redirected to login.
+      email or username: Label for the email address or username input on the login page.
+      password: Label for the password input on the login page.
+      remember: Label for the 'remember me' checkbox on the login page.
+      lost password link: Link text to the forgotten password page on the login page.
+      login_button: Button label to submit the login form.
+      with external: Label for the section with third-party login options.
+      or: Separator text between the password login form and the third-party login options.
+      reset_to_login: Message shown when the user's password has expired and they need to reset it.
+      auth failure: Flash message shown when login fails due to incorrect credentials.
+    destroy:
+      title: Page title for the logout confirmation page.
+      heading: Heading on the logout confirmation page.
+      logout_button: Button label to confirm logout.
+    suspended_flash:
+      suspended: Flash message shown when a suspended user tries to log in.
+      contact_support_html: Additional flash message for suspended users with a link to contact support. %{support_link} is the support link.
+      support: Link text for the support contact link shown to suspended users.
   shared:
     markdown_help:
-      kramdown: See https://kramdown.gettalong.org/
+      heading_html: Heading for the markdown help section, with a link to the kramdown documentation. %{kramdown_link} is the link.
+      kramdown_url: URL for the kramdown quick reference documentation.
+      kramdown: Link text for the kramdown documentation link.
+      headings: Label for the headings example in the markdown help.
+      heading: Example heading text in the markdown help.
+      subheading: Example subheading text in the markdown help.
+      unordered: Label for the unordered list example in the markdown help.
+      ordered: Label for the ordered list example in the markdown help.
+      first: First item text in the list examples in the markdown help.
+      second: Second item text in the list examples in the markdown help.
+      link: Label for the link example in the markdown help.
+      text: Placeholder text for the link text in the markdown help example.
+      image: Label for the image example in the markdown help.
+      alt: Placeholder alt text for the image in the markdown help example.
+      url: Placeholder URL in the markdown help examples.
+      codeblock: Label for the code block example in the markdown help.
+    richtext_field:
+      edit: Tab label to switch to the edit/write mode in a rich text field.
+      preview: Tab label to switch to the preview mode in a rich text field.
+      help: Button label to show the markdown help in a rich text field.
+    pagination:
+      changeset_comments:
+        older: Pagination link to go to older changeset comments.
+        newer: Pagination link to go to newer changeset comments.
+        oldest: Pagination link to go to the oldest changeset comments.
+        newest: Pagination link to go to the newest changeset comments.
+      diary_comments:
+        older: Pagination link to go to older diary comments.
+        newer: Pagination link to go to newer diary comments.
+        oldest: Pagination link to go to the oldest diary comments.
+        newest: Pagination link to go to the newest diary comments.
+      diary_entries:
+        older: Pagination link to go to older diary entries.
+        newer: Pagination link to go to newer diary entries.
+        oldest: Pagination link to go to the oldest diary entries.
+        newest: Pagination link to go to the newest diary entries.
+      issues:
+        older: Pagination link to go to older issues.
+        newer: Pagination link to go to newer issues.
+        oldest: Pagination link to go to the oldest issues.
+        newest: Pagination link to go to the newest issues.
+      traces:
+        older: Pagination link to go to older GPS traces.
+        newer: Pagination link to go to newer GPS traces.
+        oldest: Pagination link to go to the oldest GPS traces.
+        newest: Pagination link to go to the newest GPS traces.
+      user_blocks:
+        older: Pagination link to go to older user blocks.
+        newer: Pagination link to go to newer user blocks.
+        oldest: Pagination link to go to the oldest user blocks.
+        newest: Pagination link to go to the newest user blocks.
+      users:
+        older: Pagination link to go to older users in the user list.
+        newer: Pagination link to go to newer users in the user list.
+        oldest: Pagination link to go to the oldest users in the user list.
+        newest: Pagination link to go to the newest users in the user list.
   site:
+    about:
+      used_by_html: Tagline on the about page. %{name} is the project name as a link.
+      lede_text: Opening paragraph on the about page describing the project.
     about_section:
-      contribute_1_ohm_html: |-
-        See also:
-        * {{msg-ohm|ohm-site.about.contribute_1_wiki}}
-        * {{msg-ohm|ohm-site.about.contribute_1_wiki_url}}
-        * {{msg-ohm|ohm-site.about.contribute_1_forum}}
-        * {{msg-ohm|ohm-site.about.contribute_1_user_diaries}}
-        * {{msg-ohm|ohm-site.about.contribute_1_mastodon}}
-        * {{msg-ohm|ohm-site.about.contribute_1_bluesky}}
-      contribute_1_bluesky: '{{Optional}}'
-      contribute_1_mastodon: '{{Optional}}'
-      contribute_1_wiki_url: '{{Optional}}'
-      contribute_2_html: |-
-        See also:
-        * {{msg-ohm|ohm-site.about.contribute_2_create_account}}
-        * {{msg-ohm|ohm-site.about.contribute_2_donations}}
-        * {{msg-ohm|ohm-site.about.contribute_2_osmus}}
-      contribute_2_create_account: This message is the parameter %{create_account_link}
-        in {{msg-ohm|Ohm-site.about.contribute 2 html}}.
-      contribute_2_donations: This message is the parameter %{donations_link} in {{msg-ohm|Ohm-site.about.contribute
-        2 html}}.
-      contribute_2_osmus: This message is the parameter %{osmus_link} in {{msg-ohm|Ohm-site.about.contribute
-        2 html}}.
-      open_data_1_1_html: |-
-        See also:
-        * {{msg-ohm|ohm-site.about.open_data_1_1_reuse}}
-        * {{msg-ohm|ohm-site.about.open_data_1_1_reuse_url}}
-      open_data_1_1_reuse: This message is the link text for the parameter %{reuse_link}
-        in {{msg-ohm|Ohm-site.about.open data 1 1 html}}.
-      open_data_1_1_reuse_url: '{{Optional}}'
-      open_data_2_html: |-
-        See also:
-        * {{msg-ohm|ohm-site.about.open_data_2_copyright_license}}
-      legal_1_group_url: '{{Optional}}'
-      legal_3_html: |-
-        See also:
-        * {{msg-ohm|ohm-site.about.legal_3_osmf_trademarks}}
-        * {{msg-ohm|ohm-site.about.legal_3_osmf_trademarks_url}}
-      legal_3_osmf_trademarks: This message is the link text for the parameter %{osmf_trademarks_link}
-        in {{msg-ohm|Ohm-site.about.legal 3 html}}.
+      scope_title: Section heading for the scope/mission section on the about page.
+      scope_html: Body text for the scope/mission section on the about page.
+      contribute_title: Section heading for the 'how to contribute' section on the about page.
+      contribute_1_ohm_html: First paragraph of the contribute section. %{wiki_link}, %{forum_link}, %{user_diaries_link}, %{mastodon_link}, %{bluesky_link} are links.
+      contribute_1_bluesky: Link text for the Bluesky social media account link in the contribute section.
+      contribute_1_forum: Link text for the discussion forum link in the contribute section.
+      contribute_1_mastodon: Link text for the Mastodon social media account link in the contribute section.
+      contribute_1_user_diaries: Link text for the user diaries link in the contribute section.
+      contribute_1_wiki: Link text for the wiki documentation link in the contribute section.
+      contribute_1_wiki_url: URL for the wiki documentation link in the contribute section.
+      contribute_2_html: Second paragraph of the contribute section. %{create_account_link}, %{donations_link}, %{osmus_link} are links.
+      contribute_2_create_account: Link text for creating a free account in the contribute section.
+      contribute_2_donations: Link text for the donations link in the contribute section.
+      contribute_2_osmus: Link text for the OpenStreetMap U.S. link in the contribute section.
+      open_data_title: Section heading for the open data section on the about page.
+      open_data_1_1_html: First paragraph of the open data section. %{reuse_link} is a link.
+      open_data_1_1_reuse: Link text for the 'available for reuse' link in the open data section.
+      open_data_1_1_reuse_url: URL for the data reuse information page.
+      open_data_2_html: Second paragraph of the open data section. %{copyright_license_link} is a link.
+      open_data_2_copyright_license: Link text for the copyright and acknowledgements link in the open data section.
+      legal_title: Section heading for the legal section on the about page.
+      legal_1_html: First paragraph of the legal section. %{group_link}, %{terms_of_use_link}, %{aup_link}, %{privacy_policy_link} are links.
+      legal_1_group: Link text for the 'informal group' link in the legal section.
+      legal_1_group_url: URL for the governance page linked in the legal section.
+      legal_1_terms_of_use: Link text for the Terms of Use link in the legal section.
+      legal_1_terms_of_use_url: URL for the Terms of Use page.
+      legal_1_aup: Link text for the Acceptable Use Policies link in the legal section.
+      legal_1_aup_url: URL for the Acceptable Use Policy page.
+      legal_1_privacy_policy: Link text for the Privacy Policy link in the legal section.
+      legal_1_privacy_policy_url: URL for the Privacy Policy page.
+      legal_1_1_terms_of_use_url: URL for the Contributor Terms page.
+      legal_2_html: Second paragraph of the legal section with a contact link. %{contact_team_link} is a link.
+      legal_2_contact_team: Link text for contacting the team in the legal section.
+      legal_3_html: Third paragraph of the legal section about trademarks. %{osmf_trademarks_link} is a link.
+      legal_3_osmf_trademarks: Link text for the OpenStreetMap Foundation trademark policy link.
+      legal_3_osmf_trademarks_url: URL for the OpenStreetMap Foundation trademark policy.
+      partners_title: Section heading for the partners section on the about page.
     copyright:
+      title: Page title for the copyright and acknowledgements page.
+      foreign:
+        title: Section heading on translated copyright pages noting the English original takes precedence.
+        html: Text on translated copyright pages noting the English original takes precedence. %{english_original_link} is a link.
+        english_link: Link text for the English original copyright page.
+      native:
+        title: Section heading on the English copyright page about the page itself.
+        html: Text on the English copyright page. %{native_link} is a link to the translated version, %{mapping_link} is a link to start mapping.
+        native_link: Link text for the translated version of the copyright page (replace THIS_LANGUAGE_NAME_HERE with the language name).
+        mapping_link: Link text to start mapping, used on the copyright page.
       legal_babble:
-        credit_3_project: |-
-          {{optional}}
-          {{Identical|OpenHistoricalMap}}
-        more_1_ohm_html: The variable %{wiki_link} will be replaced by the text of
-          the message {{msg-ohm|Ohm-site.copyright.legal babble.more 1 wiki}}.
-        contributors_anr_communes_project: '{{Optional}}'
-        contributors_anr_communes_campop_url: '{{Optional}}'
-        contributors_newberry: '[[w:Newberry Library]]'
-        contributors_natural_earth: '[[w:Natural Earth]]'
-        contributors_more_sources_html: '%{sources_link} is {{msg-ohm|Ohm-site.copyright.legal
-          babble.contributors more sources page}}'
-        contributors_more_sources_page: This message is the parameter %{sources_link}
-          in {{msg-ohm|Ohm-site.copyright.legal babble.contributors more sources html}}
-        infringement_2_ohm_html: The variable %{contact_team_link} is replaced by
-          the text of {{msg-ohm|Ohm-site.copyright.legal babble.infringement 2 ohm
-          contact team}}.
-        infringement_2_ohm_contact_team: This message is the variable %{contact_team_link}
-          in {{msg-ohm|Ohm-site.copyright.legal babble.infringement 2 ohm html}}.
-        trademarks_1_ohm_html: The variable %{contact_team_link} is replaced by the
-          text of {{msg-ohm|Ohm-site.copyright.legal babble.trademarks 1 ohm contact
-          team}}.
-        trademarks_1_ohm_contact_team: This message is the variable %{contact_team_link}
-          in {{msg-ohm|Ohm-site.copyright.legal babble.trademarks 1 ohm html}}.
+        introduction_1_ohm_html: First paragraph of the copyright page describing the data license. %{cc0_link} is a link.
+        introduction_1_cc0: Link text for the Creative Commons CC0 dedication link.
+        introduction_1_cc0_url: URL for the Creative Commons CC0 dedication.
+        introduction_2_ohm_html: Second paragraph describing copyrighted features in the database. %{cc_by_link}, %{cc_by_sa_link}, %{license_key_link} are links.
+        introduction_2_cc_by: Link text for the Creative Commons Attribution license link.
+        introduction_2_cc_by_url: URL for the Creative Commons Attribution 4.0 license.
+        introduction_2_cc_by_sa: Link text for the Creative Commons Attribution-ShareAlike license link.
+        introduction_2_cc_by_sa_url: URL for the Creative Commons Attribution-ShareAlike 4.0 license.
+        introduction_2_license_key_url: URL for the wiki page about the license key tag.
+        introduction_3_ohm_html: Third paragraph describing the map styles license.
+        introduction_4_ohm_html: Fourth paragraph describing the documentation license. %{creative_commons_link} is a link.
+        introduction_4_creative_commons: Link text for the Creative Commons Attribution-ShareAlike 2.0 license.
+        introduction_4_creative_commons_url: URL for the Creative Commons Attribution-ShareAlike 2.0 license.
+        credit_title_html: Section heading for the 'how to credit' section on the copyright page.
+        credit_1_html: First paragraph of the credit section.
+        credit_2_ohm_html: Second paragraph of the credit section with example attribution. %{this_copyright_page_link} and %{home_link} are links.
+        credit_2_this_copyright_page: Link text for 'this copyright page' in the credit section.
+        credit_2_home: Link text for 'our homepage' in the credit section.
+        credit_3_ohm_html: Third paragraph of the credit section with a credits page example.
+        credit_3_credit_html: Example attribution text for a credits page. %{project_link} is a link.
+        credit_3_project: Link text for the project name in the example attribution.
+        credit_4_ohm_html: Fourth paragraph of the credit section with examples for print, books, and academic papers.
+        attribution_example:
+          alt: Alt text for the example attribution screenshot image.
+          title: Title attribute for the example attribution screenshot image.
+        more_title_html: Section heading for the 'finding out more' section on the copyright page.
+        more_1_ohm_html: Paragraph in the 'finding out more' section. %{wiki_link} is a link.
+        more_1_wiki: Link text for the wiki link in the 'finding out more' section.
+        more_1_wiki_url: URL for the wiki page about the license.
+        more_2_1_html: Paragraph about API and tile usage policies. %{api_usage_policy_link}, %{tile_usage_policy_link}, %{nominatim_usage_policy_link} are links.
+        more_2_1_api_usage_policy: Link text for the API Usage Policy link.
+        more_2_1_api_usage_policy_url: URL for the API Usage Policy.
+        more_2_1_tile_usage_policy: Link text for the Tile Usage Policy link.
+        more_2_1_tile_usage_policy_url: URL for the Tile Usage Policy.
+        more_2_1_nominatim_usage_policy: Link text for the Nominatim Usage Policy link.
+        more_2_1_nominatim_usage_policy_url: URL for the Nominatim Usage Policy.
+        contributors_title_html: Section heading for the acknowledgements/contributors section on the copyright page.
+        contributors_intro_html: Introductory paragraph for the contributors section.
+        contributors_anr_communes_html: Acknowledgement for the ANR COMMUNES project. %{anr_communes_link} and %{campop_link} are links.
+        contributors_anr_communes_project: Link text for the ANR COMMUNES project.
+        contributors_anr_communes_campop: Link text for the Cambridge Group for the History of Population.
+        contributors_anr_communes_campop_url: URL for the Cambridge Group project page.
+        contributors_newberry_ahcb_html: Acknowledgement for the Atlas of Historical County Boundaries. %{ahcb_link} and %{newberry_link} are links.
+        contributors_newberry: Link text for The Newberry Library.
+        contributors_newberry_ahcb: Link text for the Atlas of Historical County Boundaries.
+        contributors_osm_html: Acknowledgement for OpenStreetMap data. %{osm_link} and %{cc_by_sa_link} are links.
+        contributors_osm: Link text for OpenStreetMap contributors.
+        contributors_osm_cc_by_sa: Link text for the CC BY-SA 2.0 license.
+        contributors_osm_cc_by_sa_url: URL for the CC BY-SA 2.0 license.
+        contributors_2_ohm_html: Paragraph introducing the map style data sources.
+        contributors_natural_earth_html: Acknowledgement for Natural Earth data. %{natural_earth_link} is a link.
+        contributors_natural_earth: Link text for Natural Earth.
+        contributors_globcover_html: Acknowledgement for GlobCover land cover data. %{globcover_link} is a link.
+        contributors_globcover: Link text for GlobCover.
+        contributors_gmted_html: Acknowledgement for GMTED terrain elevation data. %{gmted_link} is a link.
+        contributors_gmted: Link text for the GMTED2010 dataset.
+        contributors_more_sources_html: Link to additional sources on the wiki. %{sources_link} is a link.
+        contributors_more_sources_page: Link text for the additional sources wiki page.
+        contributors_more_sources_page_url: URL for the additional sources wiki page.
+        contributors_footer_2_html: Disclaimer that inclusion in the database does not imply endorsement.
+        infringement_title_html: Section heading for the copyright infringement section on the copyright page.
+        infringement_1_html: First paragraph of the copyright infringement section reminding contributors not to copy from copyrighted sources.
+        infringement_2_ohm_html: Second paragraph of the copyright infringement section with a contact link. %{contact_team_link} is a link.
+        infringement_2_ohm_contact_team: Link text for the takedown request contact link.
+        trademarks_title: Section heading for the trademarks section on the copyright page.
+        trademarks_1_ohm_html: Paragraph about trademark questions with a contact link. %{contact_team_link} is a link.
+        trademarks_1_ohm_contact_team: Link text for the trademark contact link.
+    index:
+      js_1: Message shown to users with JavaScript disabled, explaining that JavaScript is needed.
+      js_2: Second message shown to users with JavaScript disabled, explaining why JavaScript is needed.
+      license:
+        copyright: Short copyright notice shown on the map page.
+        license_url: URL for the copyright page, used in the map page license notice.
+        project_url: URL for the project homepage, used in the map page license notice.
+      remote_failed: Error message shown when remote editing (JOSM/Merkaartor remote control) fails.
+    not_public_flash:
+      not_public: Flash message shown to users whose edits are not set to public.
+      not_public_description_html: Additional flash message explaining the user cannot edit until they make their edits public. %{user_page} is a link.
+      user_page_link: Link text for the user page link in the not-public flash message.
+      anon_edits_html: Parenthetical link to more information about anonymous edits. %{link} is a link.
+      anon_edits_link: URL for the wiki page about anonymous edits.
+      anon_edits_link_text: Link text for the anonymous edits information link.
+    export:
+      title: Page title for the export page.
+      manually_select: Link text to manually select a different area for export.
+      licence: Label for the licence section on the export page.
+      licence_details_ohm_html: Licence details text on the export page. %{cc0_link} and %{copyright_page_link} are links.
+      cc0: Link text for the Creative Commons CC0 dedication on the export page.
+      cc0_url: URL for the Creative Commons CC0 dedication.
+      copyright_page: Link text for the copyright page link on the export page.
+      too_large:
+        advice: Advice shown when the export area is too large, suggesting alternative sources.
+        body: Message shown when the selected area is too large to export as XML.
+        planet:
+          title: Title for the Planet OHM alternative data source.
+          description: Description of the Planet OHM data source.
+        overpass:
+          title: Title for the Overpass API alternative data source.
+          description: Description of the Overpass API data source.
+        geofabrik:
+          title: Title for the Geofabrik Downloads alternative data source.
+          description: Description of the Geofabrik Downloads data source.
+        other:
+          title: Title for other alternative data sources.
+          description: Description of other alternative data sources.
+          url: URL for the wiki page listing other data sources.
+      export_button: Button label to start the map data export.
+      export_download: Button label shown while the export is downloading.
+      confirmation:
+        header: Heading for the export confirmation dialog.
+        body: Body text for the export confirmation dialog.
+        cancel: Button label to cancel the export in the confirmation dialog.
+        download: Button label to confirm and start the download in the confirmation dialog.
     fixthemap:
+      title: Page title for the 'Report a problem / Fix the map' page.
+      how_to_help:
+        title: Section heading for the 'How to Help' section on the fix-the-map page.
+        join_the_community:
+          title: Subsection heading for joining the community.
+          explanation_html: Explanation of how to fix map problems by joining the community.
+        add_a_note:
+          instructions_1_html: Instructions for adding a note to the map. %{note_icon} is the note icon.
       other_concerns:
-        contact_url: '{{Optional}}'
+        title: Section heading for 'Other concerns' on the fix-the-map page.
+        concerns_ohm_html: Text for other concerns with links to copyright and contact pages. %{copyright_link} and %{contact_link} are links.
+        copyright: Link text for the copyright page in the other concerns section.
+        contact: Link text for the contact page in the other concerns section.
+        contact_url: URL for the contact/communication page.
     help:
+      title: Page title for the help page.
+      introduction: Introductory paragraph on the help page.
+      welcome:
+        url: URL for the welcome page, listed as a help resource.
+        title: Title for the welcome page help resource.
+        description: Description of the welcome page help resource.
+      beginners_guide:
+        url: URL for the beginners' guide help resource.
+        title: Title for the beginners' guide help resource.
+        description: Description of the beginners' guide help resource.
       community:
-        url: '{{Optional}}'
+        url: URL for the community forum help resource.
+        title: Title for the community forum help resource.
+        description: Description of the community forum help resource.
+      mailing_lists:
+        url: URL for the mailing lists help resource.
+        title: Title for the mailing lists help resource.
+        description: Description of the mailing lists help resource.
+      irc:
+        url: URL for the IRC help resource.
+        title: Title for the IRC help resource.
+        description: Description of the IRC help resource.
+      switch2osm:
+        url: URL for the switch2osm help resource.
+        title: Title for the switch2osm help resource.
+        description: Description of the switch2osm help resource.
       welcomemat:
-        url: '{{optional}}'
+        url: URL for the Welcome Mat help resource.
+        title: Title for the Welcome Mat help resource.
+        description: Description of the Welcome Mat help resource.
       discord:
-        url: '{{optional}}'
-        title: |-
-          {{optional}}
-          Name of the [[:w:en:Discord|Discord]] platform.
+        url: URL for the Discord help resource.
+        title: Title for the Discord help resource.
+        description: Description of the Discord help resource.
+      forum:
+        url: URL for the OHM forum help resource.
+        title: Title for the OHM forum help resource.
+        description: Description of the OHM forum help resource.
       github:
-        url: '{{Optional}}'
+        url: URL for the GitHub help resource.
+        title: Title for the GitHub help resource.
+        description: Description of the GitHub help resource.
+      mailing_list:
+        url: URL for the mailing list help resource.
+        title: Title for the mailing list help resource.
+        description: Description of the mailing list help resource.
+      slack:
+        url: URL for the Slack help resource.
+        title: Title for the Slack help resource.
+        description: Description of the Slack help resource.
+      wiki:
+        url: URL for the wiki help resource.
+        title: Title for the wiki help resource.
+        description: Description of the wiki help resource.
     potlatch:
-      download_url: '{{Optional}}'
+      removed: Message shown to users whose default editor is set to Potlatch, explaining it is no longer available.
+      desktop_application_html: Message about using Potlatch as a desktop application. %{download_link} is a link.
+      download: Link text for downloading the Potlatch desktop application.
+      download_url: URL for downloading the Potlatch desktop application.
+      id_editor_html: Suggestion to switch to the iD editor instead of Potlatch. %{change_preferences_link} is a link.
+      change_preferences: Link text to change editor preferences.
     any_questions:
-      welcome_mat_url: '{{optional}}'
+      title: Section heading for the 'Any questions?' section on the welcome page.
+      paragraph_1_html: Paragraph in the 'Any questions?' section with a help link. %{help_link} is a link.
+      get_help_here: Link text for the help page link in the 'Any questions?' section.
+      welcome_mat: Link text for the Welcome Mat link in the 'Any questions?' section.
+      welcome_mat_url: URL for the Welcome Mat.
+    sidebar:
+      search_results: Heading for the search results panel in the map sidebar.
     search:
+      search: Label for the search input field on the map.
+      get_directions_title: Tooltip for the directions button on the map.
+      from: Label for the 'from' input in the directions form.
+      to: Label for the 'to' input in the directions form.
+      where_am_i: Button label to reverse geocode the current map center.
+      where_am_i_title: Tooltip for the 'where am I?' button.
+      submit_text: Button label to submit the search form.
+      reverse_directions_text: Button label to reverse the start and end points in the directions form.
+      modes:
+        bicycle: Label for the bicycle routing mode in the directions form.
+        car: Label for the car routing mode in the directions form.
+        foot: Label for the foot/walking routing mode in the directions form.
       providers:
-        fossgis_osrm: '{{Optional}}'
-        graphhopper: '{{Optional}}'
-        fossgis_valhalla: '{{Optional}}'
+        description: Label for the directions service provider selector.
+        fossgis_osrm: Name of the OSRM routing service provider.
+        graphhopper: Name of the GraphHopper routing service provider.
+        fossgis_valhalla: Name of the Valhalla routing service provider.
     welcome:
+      title: Page title for the welcome page shown to new users.
+      introduction: Introductory paragraph on the welcome page.
       whats_on_the_map:
-        on_the_map_ohm_html: The variable %{past_and_present} is replaced by {{msg-ohm|ohm-site.welcome.whats
-          on the map.past and present}}.
-        off_the_map_html: The variable %{doesnt} is replaced by the text of {{msg-ohm|Ohm-site.welcome.whats
-          on the map.doesnt}}.
-        doesnt: This message is the variable %{doesnt} in the message {{msg-ohm|Ohm-site.welcome.whats
-          on the map.off the map html}}.
-  notes:
+        title: Section heading for the 'What's on the Map' section on the welcome page.
+        on_the_map_ohm_html: Description of what is mapped on OpenHistoricalMap. %{past_and_present} is a link.
+        past_and_present: Link text for 'both the past and present' in the welcome page.
+        off_the_map_html: Description of what is not mapped on OpenHistoricalMap. %{doesnt} is emphasized text.
+        doesnt: Emphasized word 'doesn't' used in the off-the-map description.
+      basic_terms:
+        title: Section heading for the 'Basic Terms For Mapping' section on the welcome page.
+        paragraph_1: Introductory paragraph for the basic terms section.
+        an_editor_html: Definition of 'editor' on the welcome page. %{editor} is a link.
+        a_node_html: Definition of 'node' on the welcome page. %{node} is a link.
+        a_way_html: Definition of 'way' on the welcome page. %{way} is a link.
+        a_tag_html: Definition of 'tag' on the welcome page. %{tag} is a link.
+        editor: Link text for the 'editor' term in the basic terms section.
+        node: Link text for the 'node' term in the basic terms section.
+        way: Link text for the 'way' term in the basic terms section.
+        tag: Link text for the 'tag' term in the basic terms section.
+      rules:
+        title: Section heading for the 'Rules!' section on the welcome page.
+        para_1_html: Paragraph about community rules and guidelines. %{imports_link} and %{automated_edits_link} are links.
+        imports: Link text for the imports guidelines link.
+        imports_url: URL for the imports guidelines wiki page.
+        automated_edits: Link text for the automated edits guidelines link.
+        automated_edits_url: URL for the automated edits code of conduct wiki page.
+      start_mapping: Button label to start mapping, shown at the bottom of the welcome page.
+      continue_authorization: Button label to continue an OAuth authorization flow after the welcome page.
+    add_a_note:
+      title: Section heading for the 'Add a Note' section on the welcome page.
+      para_1: First paragraph explaining how to add a note without signing up.
+      para_2_html: Second paragraph with instructions for adding a note. %{note_icon} is the note icon, %{map_link} is a link.
+      the_map: Link text for 'the map' in the add-a-note section.
+    communities:
+      title: Page title for the communities page.
+      lede_text: Introductory paragraph on the communities page.
+      local_chapters:
+        title: Section heading for the Local Chapters section on the communities page.
+        about_text: Description of what Local Chapters are.
+        list_text: Introductory text before the list of Local Chapters.
+      other_groups:
+        title: Section heading for the Other Groups section on the communities page.
+        other_groups_html: Description of other community groups. %{communities_wiki_link} is a link.
+        communities_wiki: Link text for the communities wiki page.
+        communities_wiki_url: URL for the communities wiki page.
+  social_links:
+    show:
+      website: Label for the website link type in the social profile links section.
+  layers_panes:
+    show:
+      map_notes_zoom_in_tooltip: Tooltip shown on the map notes layer toggle when the user needs to zoom in to see notes.
+      map_data_zoom_in_tooltip: Tooltip shown on the map data layer toggle when the user needs to zoom in to see data.
+  legend_panes:
+    show:
+      entries:
+        motorway: Legend entry label for motorway roads.
+        main_road: Legend entry label for main roads.
+        trunk: Legend entry label for trunk roads.
+        primary: Legend entry label for primary roads.
+        secondary: Legend entry label for secondary roads.
+        unclassified: Legend entry label for unclassified roads.
+        pedestrian: Legend entry label for pedestrian ways.
+        track: Legend entry label for tracks.
+        bridleway: Legend entry label for bridleways.
+        cycleway: Legend entry label for cycleways.
+        international_bike_route: Legend entry label for international cycling routes.
+        national_bike_route: Legend entry label for national cycling routes.
+        regional_bike_route: Legend entry label for regional cycling routes.
+        local_bike_route: Legend entry label for local cycling routes.
+        mountain_bike_route: Legend entry label for mountain bike routes.
+        footway: Legend entry label for footways.
+        rail: Legend entry label for railways.
+        train: Legend entry label for train services.
+        subway: Legend entry label for subway/metro lines.
+        ferry: Legend entry label for ferry routes.
+        light_rail: Legend entry label for light rail lines.
+        tram: Legend entry label for tram lines.
+        trolleybus: Legend entry label for trolleybus routes.
+        bus: Legend entry label for bus routes.
+        cable_car: Legend entry label for cable cars.
+        chair_lift: Legend entry label for chair lifts.
+        runway: Legend entry label for airport runways.
+        taxiway: Legend entry label for airport taxiways.
+        apron: Legend entry label for airport aprons.
+        admin: Legend entry label for administrative boundaries.
+        capital: Legend entry label for capital cities.
+        city: Legend entry label for cities.
+        orchard: Legend entry label for orchards.
+        vineyard: Legend entry label for vineyards.
+        forest: Legend entry label for forests.
+        wood: Legend entry label for woods.
+        farmland: Legend entry label for farmland.
+        grass: Legend entry label for grass areas.
+        meadow: Legend entry label for meadows.
+        bare_rock: Legend entry label for bare rock areas.
+        sand: Legend entry label for sand areas.
+        golf: Legend entry label for golf courses.
+        park: Legend entry label for parks.
+        common: Legend entry label for common land.
+        built_up: Legend entry label for built-up areas.
+        resident: Legend entry label for residential areas.
+        retail: Legend entry label for retail areas.
+        industrial: Legend entry label for industrial areas.
+        commercial: Legend entry label for commercial areas.
+        heathland: Legend entry label for heathland.
+        scrubland: Legend entry label for scrubland.
+        lake: Legend entry label for lakes.
+        reservoir: Legend entry label for reservoirs.
+        intermittent_water: Legend entry label for intermittent water bodies.
+        glacier: Legend entry label for glaciers.
+        reef: Legend entry label for reefs.
+        wetland: Legend entry label for wetlands.
+        farm: Legend entry label for farms.
+        brownfield: Legend entry label for brownfield sites.
+        cemetery: Legend entry label for cemeteries.
+        allotments: Legend entry label for allotments.
+        pitch: Legend entry label for sports pitches.
+        centre: Legend entry label for sports centres.
+        beach: Legend entry label for beaches.
+        reserve: Legend entry label for nature reserves.
+        military: Legend entry label for military areas.
+        school: Legend entry label for schools.
+        university: Legend entry label for universities.
+        hospital: Legend entry label for hospitals.
+        building: Legend entry label for significant buildings.
+        station: Legend entry label for railway stations.
+        railway_halt: Legend entry label for railway halts.
+        subway_station: Legend entry label for subway stations.
+        tram_stop: Legend entry label for tram stops.
+        summit: Legend entry label for summits.
+        peak: Legend entry label for peaks.
+        tunnel: Legend entry label explaining the dashed casing style for tunnels.
+        bridge: Legend entry label explaining the black casing style for bridges.
+        private: Legend entry label for private access roads.
+        destination: Legend entry label for destination-access roads.
+        construction: Legend entry label for roads under construction.
+        bus_stop: Legend entry label for bus stops.
+        bicycle_shop: Legend entry label for bicycle shops.
+        bicycle_rental: Legend entry label for bicycle rental stations.
+        bicycle_parking: Legend entry label for bicycle parking.
+        bicycle_parking_small: Legend entry label for small bicycle parking.
+        toilets: Legend entry label for toilets.
+      see_external_legend: Link text to view the external map legend for the current layer.
+  share_panes:
+    show:
+      link: Label for the link/HTML sharing option in the share panel.
+      include_marker: Checkbox label to include a map marker in the shared link.
+      long_link: Label for the full-length URL in the share panel.
+      short_link: Label for the shortened URL in the share panel.
+      embed: Label for the HTML embed code option in the share panel.
+      embed_html_disabled: Message shown when HTML embedding is not available for the current map layer.
+      paste_html: Instruction text to paste the HTML embed code into a website.
+      geo_uri: Label for the Geo URI option in the share panel.
+      image: Label for the image export option in the share panel.
+      only_layers_exported_as_image: Message listing which layers can be exported as an image.
+      format: Label for the image format selector in the share panel.
+      scale: Label for the image scale selector in the share panel.
+      custom_dimensions: Link text to set custom image dimensions in the share panel.
+      image_dimensions_html: Text showing the image dimensions for the selected layer. %{layer} is the layer name, %{width} and %{height} are pixel dimensions.
+      download: Button label to download the map image.
+      downloading: Button label shown while the map image is being downloaded.
+  webgl_error_panes:
+    show:
+      compact_message: Short error message shown when WebGL is required but not available.
+      description_html: Longer description of the WebGL error. %{your_browser_does_not_support_webgl} is a phrase used as a link.
+      your_browser_does_not_support_webgl: Phrase used as link text in the WebGL error description.
+      webgl_is_required_for_this_map: Message stating that WebGL is required to display the map.
+      read_more_about_webgl: Link text to read more about WebGL requirements.
+      read_more_about_webgl_url: URL for the wiki page about WebGL requirements.
+  traces:
+    visibility:
+      private: Description of the 'private' GPS trace visibility option.
+      public: Description of the 'public' GPS trace visibility option.
+      trackable: Description of the 'trackable' GPS trace visibility option.
+      identifiable: Description of the 'identifiable' GPS trace visibility option.
     new:
+      upload_trace: Page title and heading for the GPS trace upload page.
+      visibility_help: Link text for the GPS trace visibility help link.
+      visibility_help_url: URL for the wiki page explaining GPS trace visibility options.
+      help: Label for the general help link on the trace upload page.
+      help_url: URL for the wiki page about uploading GPS traces.
+    create:
+      upload_trace: Heading shown after a GPS trace is uploaded.
+      trace_uploaded: Flash message shown after a GPS trace is successfully uploaded and queued for processing.
+      upload_failed: Flash message shown when a GPS trace upload fails.
+      traces_waiting:
+        one: Message shown when the user has one trace waiting to be processed. %{count} is the number.
+        other: Message shown when the user has multiple traces waiting to be processed. %{count} is the number.
+    edit:
+      cancel: Button label to cancel editing a GPS trace.
+      title: Page title for the GPS trace edit page. %{name} is the trace filename.
+      heading: Heading for the GPS trace edit page. %{name} is the trace filename.
+      visibility_help: Link text for the GPS trace visibility help link on the edit page.
+      visibility_help_url: URL for the wiki page explaining GPS trace visibility options.
+    update:
+      updated: Flash message shown after a GPS trace is successfully updated.
+    show:
+      title: Page title for the GPS trace detail page. %{name} is the trace filename.
+      heading: Heading for the GPS trace detail page. %{name} is the trace filename.
+      pending: Badge label shown for a GPS trace that is pending processing.
+      filename: Label for the filename field on the trace detail page.
+      download: Link text to download the GPS trace file.
+      uploaded: Label for the upload date field on the trace detail page.
+      points: Label for the number of GPS points field on the trace detail page.
+      start_coordinates: Label for the start coordinates field on the trace detail page.
+      coordinates_html: Format for displaying coordinates on the trace detail page. %{latitude} and %{longitude} are the coordinate values.
+      map: Link text to view the GPS trace on the map.
+      edit: Link text to edit the GPS trace.
+      owner: Label for the owner field on the trace detail page.
+      description: Label for the description field on the trace detail page.
+      tags: Label for the tags field on the trace detail page.
+      none: Text shown when a field has no value on the trace detail page.
+      edit_trace: Link text to edit the GPS trace on the detail page.
+      delete_trace: Link text to delete the GPS trace on the detail page.
+      trace_not_found: Message shown when a GPS trace cannot be found.
+      visibility: Label for the visibility field on the trace detail page.
+      confirm_delete: Confirmation prompt before deleting a GPS trace.
+    trace:
+      pending: Badge label shown for a pending GPS trace in the trace list.
+      count_points:
+        one: Singular count of GPS points in a trace. %{count} is the number.
+        other: Plural count of GPS points in a trace. %{count} is the number.
+      more: Link text to see more details about a GPS trace.
+      trace_details: Link text to view the GPS trace details page.
+      view_map: Link text to view the GPS trace on the map.
+      edit_map: Link text to edit the map at the GPS trace location.
+      public: Badge label for a public GPS trace.
+      identifiable: Badge label for an identifiable GPS trace.
+      private: Badge label for a private GPS trace.
+      trackable: Badge label for a trackable GPS trace.
+      details_with_tags_html: Summary line for a GPS trace with tags. %{time_ago} is the upload time, %{user} is the uploader, %{tags} are the tags.
+      details_without_tags_html: Summary line for a GPS trace without tags. %{time_ago} is the upload time, %{user} is the uploader.
+    index:
+      public_traces: Page title for the public GPS traces list.
+      my_gps_traces: Page title for the user's own GPS traces list.
+      public_traces_from: Page title for the public GPS traces from a specific user. %{user} is the username.
+      description: Meta description for the GPS traces index page.
+      tagged_with: Text appended to the page description when filtering by tag. %{tags} is the tag.
+      empty_title: Heading shown when there are no GPS traces to display.
+      empty_upload_html: Message shown when there are no GPS traces, with links to upload and learn more. %{upload_link} and %{wiki_link} are links.
+      upload_new: Link text to upload a new GPS trace.
+      wiki_page: Link text for the GPS tracing wiki page.
+      wiki_page_url: URL for the GPS tracing beginners guide wiki page.
+      upload_trace: Link text to upload a GPS trace in the traces list.
+      all_traces: Tab label to show all public GPS traces.
+      my_traces: Tab label to show only the user's own GPS traces.
+      traces_from_html: Tab label to show public traces from a specific user. %{user} is the username.
+      remove_tag_filter: Link text to remove the current tag filter from the traces list.
+    destroy:
+      scheduled_for_deletion: Flash message shown after a GPS trace is scheduled for deletion.
+    offline_warning:
+      message: Warning message shown when the GPS file upload system is temporarily unavailable.
+    offline:
+      heading: Heading shown when the GPS storage system is offline.
+      message: Message shown when the GPS file storage and upload system is unavailable.
+    feeds:
+      show:
+        title: Title for the GPS traces RSS/Atom feed.
+      description:
+        description_with_count:
+          one: Feed item description for a GPS trace with one point. %{count} is the number, %{user} is the uploader.
+          other: Feed item description for a GPS trace with multiple points. %{count} is the number, %{user} is the uploader.
+        description_without_count: Feed item description for a GPS trace when the point count is unknown. %{user} is the uploader.
+  application:
+    permission_denied: Flash message shown when a user tries to access an action they don't have permission for.
+    require_cookies:
+      cookies_needed: Flash message shown when cookies are disabled in the browser.
+    setup_user_auth:
+      blocked_zero_hour: Flash message shown to a user who has an urgent unread block message before they can save edits.
+      blocked: Flash message shown to a user whose API access has been blocked.
+      need_to_see_terms: Flash message shown to a user whose API access is suspended until they view the Contributor Terms.
+    settings_menu:
+      account_settings: Label for the account settings link in the user settings dropdown menu.
+      oauth2_applications: Label for the OAuth 2 applications link in the user settings dropdown menu.
+      oauth2_authorizations: Label for the OAuth 2 authorizations link in the user settings dropdown menu.
+      muted_users: Label for the muted users link in the user settings dropdown menu.
+    auth_providers:
+      google:
+        title: Tooltip/title for the 'Log in with Google' button.
+        alt: Alt text for the Google logo on the login button.
+      apple:
+        title: Tooltip/title for the 'Log in with Apple' button.
+        alt: Alt text for the Apple logo on the login button.
+      facebook:
+        title: Tooltip/title for the 'Log in with Facebook' button.
+        alt: Alt text for the Facebook logo on the login button.
+      microsoft:
+        title: Tooltip/title for the 'Log in with Microsoft' button.
+        alt: Alt text for the Microsoft logo on the login button.
+      github:
+        title: Tooltip/title for the 'Log in with GitHub' button.
+        alt: Alt text for the GitHub logo on the login button.
+      wikipedia:
+        title: Tooltip/title for the 'Log in with Wikipedia' button.
+        alt: Alt text for the Wikipedia logo on the login button.
+      openstreetmap:
+        title: Tooltip/title for the 'Log in with OpenStreetMap' button.
+        alt: Alt text for the OpenStreetMap logo on the login button.
+    share:
+      share:
+        title: Tooltip/title for the share button.
+        alt: Alt text for the share icon.
+      email:
+        title: Tooltip/title for the share via email button.
+        alt: Alt text for the email share icon.
+      bluesky:
+        title: Tooltip/title for the share via Bluesky button.
+        alt: Alt text for the Bluesky share icon.
+      facebook:
+        title: Tooltip/title for the share via Facebook button.
+        alt: Alt text for the Facebook share icon.
+      linkedin:
+        title: Tooltip/title for the share via LinkedIn button.
+        alt: Alt text for the LinkedIn share icon.
+      mastodon:
+        title: Tooltip/title for the share on Mastodon button.
+        alt: Alt text for the Mastodon share icon.
+      telegram:
+        title: Tooltip/title for the share on Telegram button.
+        alt: Alt text for the Telegram share icon.
+      x:
+        title: Tooltip/title for the share on X (formerly Twitter) button.
+        alt: Alt text for the X share icon.
+  oauth:
+    permissions:
+      missing: Error message shown when an application tries to use a permission it was not granted.
+    scopes:
+      openid: Description of the 'openid' OAuth scope, shown during authorization.
+      read_prefs: Description of the 'read_prefs' OAuth scope, shown during authorization.
+      write_prefs: Description of the 'write_prefs' OAuth scope, shown during authorization.
+      write_diary: Description of the 'write_diary' OAuth scope, shown during authorization.
+      write_api: Description of the 'write_api' OAuth scope, shown during authorization.
+      write_changeset_comments: Description of the 'write_changeset_comments' OAuth scope, shown during authorization.
+      read_gpx: Description of the 'read_gpx' OAuth scope, shown during authorization.
+      write_gpx: Description of the 'write_gpx' OAuth scope, shown during authorization.
+      write_notes: Description of the 'write_notes' OAuth scope, shown during authorization.
+      write_redactions: Description of the 'write_redactions' OAuth scope, shown during authorization.
+      write_blocks: Description of the 'write_blocks' OAuth scope, shown during authorization.
+      read_email: Description of the 'read_email' OAuth scope, shown during authorization.
+      consume_messages: Description of the 'consume_messages' OAuth scope, shown during authorization.
+      send_messages: Description of the 'send_messages' OAuth scope, shown during authorization.
+      skip_authorization: Description of the 'skip_authorization' OAuth scope (auto-approve), shown during authorization.
+    for_roles:
+      moderator: Note shown next to OAuth scopes that are only available to moderators.
+  oauth2_applications:
+    index:
+      title: Page title for the list of the user's registered OAuth 2 applications.
+      no_applications_html: Message shown when the user has no registered applications. %{oauth2} is a link.
+      oauth_2: Link text for 'OAuth 2' in the no-applications message.
+      new: Link text to register a new OAuth 2 application.
+      name: Column header for the application name in the OAuth 2 applications list.
+      permissions: Column header for the permissions in the OAuth 2 applications list.
+    application:
+      edit: Link text to edit an OAuth 2 application.
+      delete: Link text to delete an OAuth 2 application.
+      confirm_delete: Confirmation prompt before deleting an OAuth 2 application.
+    new:
+      title: Page title for the register new OAuth 2 application page.
+    edit:
+      title: Page title for the edit OAuth 2 application page.
+    show:
+      edit: Link text to edit the OAuth 2 application on the detail page.
+      delete: Link text to delete the OAuth 2 application on the detail page.
+      confirm_delete: Confirmation prompt before deleting an OAuth 2 application on the detail page.
+      client_id: Label for the client ID field on the OAuth 2 application detail page.
+      client_secret: Label for the client secret field on the OAuth 2 application detail page.
+      client_secret_warning: Warning message to save the client secret as it won't be shown again.
+      permissions: Label for the permissions section on the OAuth 2 application detail page.
+      redirect_uris: Label for the redirect URIs section on the OAuth 2 application detail page.
+    not_found:
+      sorry: Message shown when an OAuth 2 application cannot be found.
+  oauth2_authorizations:
+    new:
+      title: Page title for the OAuth 2 authorization page.
+      introduction: Introduction text on the OAuth 2 authorization page. %{application} is the application name.
+      authorize: Button label to grant authorization to the OAuth 2 application.
+      deny: Button label to deny authorization to the OAuth 2 application.
+    error:
+      title: Page title for the OAuth 2 authorization error page.
+    show:
+      title: Page title for the OAuth 2 authorization code page.
+  oauth2_authorized_applications:
+    index:
+      title: Page title for the list of authorized OAuth 2 applications.
+      application: Column header for the application name in the authorized applications list.
+      permissions: Column header for the permissions in the authorized applications list.
+      last_authorized: Column header for the last authorization date in the authorized applications list.
+      no_applications_html: Message shown when the user has no authorized applications. %{oauth2} is a link.
+      oauth_2: Link text for 'OAuth 2' in the no-authorized-applications message.
+    application:
+      revoke: Button label to revoke access for an authorized OAuth 2 application.
+      confirm_revoke: Confirmation prompt before revoking access for an OAuth 2 application.
+  users:
+    new:
+      title: Page title for the sign-up page.
+      tab_title: Browser tab title for the sign-up page.
+      signup_to_authorize_html: Message shown when signing up to authorize a third-party application. %{client_app_name} is the application name.
+      no_auto_account_create: Message shown when automatic account creation is not available.
+      please_contact_support_html: Message asking the user to contact support to create an account. %{support_link} is a link.
+      support: Link text for the support contact link on the sign-up page.
+      about:
+        header: Heading for the 'about the project' section on the sign-up page.
+        paragraph_1: First paragraph about the project on the sign-up page.
+        paragraph_2: Second paragraph encouraging sign-up on the sign-up page.
+        welcome: Welcome message shown on the sign-up page.
+      duplicate_social_email: Message shown when a social login email already exists, advising the user to log in with their password.
+      display name description: Help text describing the display name field on the sign-up page.
+      by_signing_up:
+        html: Terms agreement text shown on the sign-up page. %{tou_link}, %{privacy_policy_link}, %{contributor_terms_link} are links.
+        tou: Link text for the Terms of Use in the sign-up agreement.
+        privacy_policy: Link text for the privacy policy in the sign-up agreement.
+        privacy_policy_url: URL for the privacy policy.
+        privacy_policy_title: Title attribute for the privacy policy link.
+        contributor_terms_url: URL for the contributor terms.
+        contributor_terms: Link text for the contributor terms in the sign-up agreement.
+      continue: Button label to submit the sign-up form.
+      email_help:
+        privacy_policy: Link text for the privacy policy in the email help text.
+        privacy_policy_url: URL for the privacy policy, used in the email help text.
+        privacy_policy_title: Title attribute for the privacy policy link in the email help text.
+        html: Help text explaining that the email address is not displayed publicly. %{privacy_policy_link} is a link.
+      or: Separator text between the sign-up form and the third-party sign-up options.
+      use external auth: Label for the section with third-party sign-up options.
+      verify_human: Label for the CAPTCHA/human verification field on the sign-up page.
+    create:
+      not_human: Error message shown when the CAPTCHA verification fails during sign-up.
+    no_such_user:
+      title: Page title when a user profile cannot be found.
+      heading: Heading when a user profile cannot be found. %{user} is the username.
+      body: Body text when a user profile cannot be found. %{user} is the username.
+      deleted: Text shown when a user has been deleted.
+    show:
+      my diary: Link text to the user's own diary.
+      my edits: Link text to the user's own edits/changesets.
+      my traces: Link text to the user's own GPS traces.
+      my notes: Link text to the user's own map notes.
+      my messages: Link text to the user's own messages.
+      my profile: Link text to the user's own profile.
+      my_account: Link text to the user's account settings.
+      my comments: Link text to the user's own comments.
+      my_preferences: Link text to the user's preferences.
+      my_dashboard: Link text to the user's dashboard.
+      blocks on me: Link text to view blocks placed on the current user.
+      blocks by me: Link text to view blocks placed by the current user (moderators only).
+      create_mute: Button label to mute a user.
+      destroy_mute: Button label to unmute a user.
+      send message: Link text to send a message to the user.
+      diary: Link text to view a user's diary on their profile page.
+      edits: Link text to view a user's edits on their profile page.
+      traces: Link text to view a user's GPS traces on their profile page.
+      notes: Link text to view a user's map notes on their profile page.
+      unfollow: Button label to unfollow a user.
+      follow: Button label to follow a user.
+      mapper since: Label for the 'mapper since' date on a user profile.
+      last map edit: Label for the 'last map edit' date on a user profile.
+      no activity yet: Text shown when a user has no map editing activity yet.
+      uid: Label for the user ID field on a user profile (shown to admins).
+      ct status: Label for the contributor terms status field on a user profile (shown to admins).
+      ct undecided: Value for contributor terms status when the user has not yet decided.
+      ct declined: Value for contributor terms status when the user has declined.
+      email address: Label for the email address field on a user profile (shown to admins).
+      created from: Label for the IP address the account was created from (shown to admins).
+      status: Label for the account status field on a user profile (shown to admins).
+      spam score: Label for the spam score field on a user profile (shown to admins).
+      block_history: Link text to view active blocks on a user (shown to moderators).
+      moderator_history: Link text to view blocks given by a user (shown to moderators).
+      revoke_all_blocks: Button label to revoke all active blocks on a user (shown to moderators).
+      comments: Label for the comments section on a user profile.
+      create_block: Button label to create a new block on a user (shown to moderators).
+      activate_user: Button label to activate a user account (shown to admins).
+      confirm_user: Button label to confirm a user account (shown to admins).
+      unconfirm_user: Button label to unconfirm a user account (shown to admins).
+      suspend_user: Button label to suspend a user account (shown to admins).
+      unsuspend_user: Button label to unsuspend a user account (shown to admins).
+      hide_user: Button label to hide a user account (shown to admins).
+      unhide_user: Button label to unhide a user account (shown to admins).
+      delete_user: Button label to delete a user account (shown to admins).
+      confirm: Button label to confirm an admin action on a user profile.
+      report: Link text to report a user.
+      edit_profile_details: Link text to edit profile details.
+      edit_description: Link text to edit the profile description.
+      edit_links: Link text to edit the profile social links.
+      change_image: Link text to change the profile image.
+      edit_company: Link text to edit the profile company.
+      edit_location: Link text to edit the profile location.
+      edit_contribution_calendar: Link text to configure the contribution calendar.
+      contributions:
+        one: Singular count of contributions in the last year on a user profile. %{count} is the number.
+        other: Plural count of contributions in the last year on a user profile. %{count} is the number.
+      title:
+        administrator: Tooltip for the administrator role icon on a user profile.
+        moderator: Tooltip for the moderator role icon on a user profile.
+        importer: Tooltip for the importer role icon on a user profile.
+      grant:
+        administrator: Button label to grant administrator access to a user.
+        moderator: Button label to grant moderator access to a user.
+        importer: Button label to grant importer access to a user.
+        are_you_sure: Confirmation prompt before granting a role to a user. %{role} is the role name, %{name} is the username.
+      revoke:
+        administrator: Button label to revoke administrator access from a user.
+        moderator: Button label to revoke moderator access from a user.
+        importer: Button label to revoke importer access from a user.
+        are_you_sure: Confirmation prompt before revoking a role from a user. %{role} is the role name, %{name} is the username.
+    sidebar_section:
+      home_location: Label for the home location section in the user profile sidebar.
+      company: Label for the company section in the user profile sidebar.
+      company_tooltip: Tooltip explaining that the company affiliation is self-reported.
+    go_public:
+      flash success: Flash message shown after making all edits public.
+    issued_blocks:
+      show:
+        title: Page title for the list of blocks issued by a user. %{name} is the username.
+        heading_html: Heading for the list of blocks issued by a user. %{name} is the username as a link.
+        empty: Message shown when a user has not issued any blocks. %{name} is the username.
+    received_blocks:
+      show:
+        title: Page title for the list of blocks received by a user. %{name} is the username.
+        heading_html: Heading for the list of blocks received by a user. %{name} is the username as a link.
+        empty: Message shown when a user has not been blocked. %{name} is the username.
+      edit:
+        title: Page title for the revoke-all-blocks page. %{block_on} is the blocked user's name.
+        heading_html: Heading for the revoke-all-blocks page. %{block_on} is the blocked user's name as a link.
+        empty: Message shown when a user has no active blocks to revoke. %{name} is the username.
+        confirm: Confirmation prompt before revoking all blocks. %{active_blocks} is the formatted count of active blocks.
+        active_blocks:
+          one: Singular count of active blocks in the revoke-all confirmation. %{count} is the number.
+          other: Plural count of active blocks in the revoke-all confirmation. %{count} is the number.
+        revoke: Button label to confirm revoking all blocks.
+      destroy:
+        flash: Flash message shown after all active blocks have been revoked.
+    lists:
+      show:
+        title: Page title for the admin user list.
+        heading: Heading for the admin user list.
+        select_status: Placeholder label for the status filter dropdown on the user list.
+        states:
+          pending: Status filter option for pending users.
+          active: Status filter option for active users.
+          confirmed: Status filter option for confirmed users.
+          suspended: Status filter option for suspended users.
+          deleted: Status filter option for deleted users.
+        name_or_email: Label for the name or email search field on the user list.
+        ip_address: Label for the IP address search field on the user list.
+        edits: Label for the edits filter on the user list.
+        has_edits: Option label for filtering users who have made edits.
+        no_edits: Option label for filtering users who have not made edits.
+        search: Button label to submit the user list search form.
+      page:
+        found_users:
+          one: Singular count of users found in the search results. %{count} is the number.
+          other: Plural count of users found in the search results. %{count} is the number.
+        confirm: Button label to confirm selected users in the admin user list.
+        suspend: Button label to suspend selected users in the admin user list.
+        empty: Message shown when no users match the search criteria.
+      user:
+        summary_html: Summary line for a user in the admin list. %{name} is the username, %{ip_address} is the IP, %{date} is the creation date.
+        summary_no_ip_html: Summary line for a user in the admin list when no IP is available. %{name} is the username, %{date} is the creation date.
+    comments:
+      index:
+        heading_html: Heading for the user comments page. %{user} is the username as a link.
+        changesets: Tab label for changeset comments on the user comments page.
+        diary_entries: Tab label for diary entry comments on the user comments page.
+        no_comments: Message shown when a user has no comments.
+    changeset_comments:
+      index:
+        title: Page title for the changeset comments added by a user. %{user} is the username.
+      page:
+        changeset: Column header for the changeset in the changeset comments table.
+        when: Column header for the date in the changeset comments table.
+        comment: Column header for the comment text in the changeset comments table.
+    diary_comments:
+      index:
+        title: Page title for the diary comments added by a user. %{user} is the username.
+      page:
+        post: Column header for the diary post in the diary comments table.
+        when: Column header for the date in the diary comments table.
+        comment: Column header for the comment text in the diary comments table.
+    suspended:
+      title: Page title for the account suspended page.
+      heading: Heading for the account suspended page.
+      support: Link text for the support contact link on the suspended page.
+      automatically_suspended: Message shown when an account has been automatically suspended.
+      contact_support_html: Message on the suspended page with a link to contact support. %{support_link} is a link.
+    auth_failure:
+      connection_failed: Error message shown when the connection to the authentication provider fails.
+      invalid_credentials: Error message shown when the authentication credentials are invalid.
+      no_authorization_code: Error message shown when no authorization code is received from the provider.
+      unknown_signature_algorithm: Error message shown when an unknown signature algorithm is used.
+      invalid_scope: Error message shown when an invalid OAuth scope is requested.
+      unknown_error: Generic error message shown when authentication fails for an unknown reason.
+    auth_association:
+      heading: Heading shown when a third-party ID is not yet associated with an account.
+      option_1: Text explaining the option to create a new account when associating a third-party ID.
+      option_2: Text explaining the option to log in with an existing account to associate the third-party ID.
+    role_icons:
+      title:
+        administrator: Tooltip for the administrator role icon.
+        moderator: Tooltip for the moderator role icon.
+        importer: Tooltip for the importer role icon.
+      grant:
+        administrator: Button label to grant administrator access.
+        moderator: Button label to grant moderator access.
+        importer: Button label to grant importer access.
+        are_you_sure: Confirmation prompt before granting a role. %{role} is the role name, %{name} is the username.
+      revoke:
+        administrator: Button label to revoke administrator access.
+        moderator: Button label to revoke moderator access.
+        importer: Button label to revoke importer access.
+        are_you_sure: Confirmation prompt before revoking a role. %{role} is the role name, %{name} is the username.
+  user_role:
+    filter:
+      not_a_role: Error message shown when an invalid role string is used. %{role} is the invalid role string.
+      already_has_role: Error message shown when trying to grant a role the user already has. %{role} is the role name.
+      doesnt_have_role: Error message shown when trying to revoke a role the user doesn't have. %{role} is the role name.
+      not_revoke_admin_current_user: Error message shown when trying to revoke the administrator role from the currently logged-in user.
+  user_blocks:
+    model:
+      non_moderator_update: Error message shown when a non-moderator tries to create or update a block.
+      non_moderator_revoke: Error message shown when a non-moderator tries to revoke a block.
+    not_found:
+      sorry: Message shown when a user block cannot be found. %{id} is the block ID.
+      back: Link text to go back to the user blocks index.
+    new:
+      title: Page title for the create user block page. %{name} is the username.
+      heading_html: Heading for the create user block page. %{name} is the username as a link.
+      period: Help text explaining the block period field.
+    edit:
+      title: Page title for the edit user block page. %{name} is the username.
+      heading_html: Heading for the edit user block page. %{name} is the username as a link.
+      period: Help text explaining the block period field on the edit page.
+      revoke: Button label to revoke a block on the edit page.
+    filter:
+      block_period: Error message shown when an invalid block period is selected.
+    create:
+      flash: Flash message shown after successfully creating a user block. %{name} is the blocked user's username.
+    update:
+      only_creator_can_edit: Error message shown when a moderator other than the creator tries to edit a block.
+      only_creator_can_edit_without_revoking: Error message shown when a moderator other than the creator tries to edit a block without revoking it.
+      only_creator_or_revoker_can_edit: Error message shown when a moderator other than the creator or revoker tries to edit a block.
+      inactive_block_cannot_be_reactivated: Error message shown when trying to reactivate an inactive block.
+      success: Flash message shown after successfully updating a user block.
+    index:
+      title: Page title for the user blocks list.
+      heading: Heading for the user blocks list.
+      empty: Message shown when there are no user blocks.
+    helper:
+      time_future_html: Text showing when an active block ends. %{time} is the relative time.
+      until_login: Text shown for a block that remains active until the user logs in.
+      time_future_and_until_login_html: Text for a block that ends at a future time and after the user logs in. %{time} is the relative time.
+      time_past_html: Text showing when a past block ended. %{time} is the relative time.
+      block_duration:
+        hours:
+          one: Singular block duration in hours. %{count} is the number.
+          other: Plural block duration in hours. %{count} is the number.
+        days:
+          one: Singular block duration in days. %{count} is the number.
+          other: Plural block duration in days. %{count} is the number.
+        weeks:
+          one: Singular block duration in weeks. %{count} is the number.
+          other: Plural block duration in weeks. %{count} is the number.
+        months:
+          one: Singular block duration in months. %{count} is the number.
+          other: Plural block duration in months. %{count} is the number.
+        years:
+          one: Singular block duration in years. %{count} is the number.
+          other: Plural block duration in years. %{count} is the number.
+      short:
+        ended: Short status label for a block that has ended.
+        revoked_html: Short status label for a block that was revoked. %{name} is the revoker's name as a link.
+        active: Short status label for an active block.
+        active_until_read: Short status label for a block that is active until the user reads it.
+        read_html: Short status label showing when a block was read. %{time} is the timestamp as a link.
+        time_in_future_title: Title attribute for a future time, showing absolute and relative time. %{time_absolute} and %{time_relative} are the times.
+        time_in_past_title: Title attribute for a past time, showing absolute and relative time. %{time_absolute} and %{time_relative} are the times.
+    show:
+      title: Page title for a user block detail page. %{block_on} is the blocked user, %{block_by} is the blocking moderator.
+      heading_html: Heading for a user block detail page. %{block_on} and %{block_by} are names as links.
+      created: Label for the creation date of a user block.
+      duration: Label for the duration of a user block.
+      status: Label for the status of a user block.
+      edit: Link text to edit a user block.
+      reason: Label for the reason section of a user block.
+      revoker: Label for the revoker field of a user block.
+    block:
+      show: Link text to view a user block.
+      edit: Link text to edit a user block.
+    page:
+      display_name: Column header for the blocked user in the user blocks table.
+      creator_name: Column header for the block creator in the user blocks table.
+      reason: Column header for the block reason in the user blocks table.
+      start: Column header for the block start date in the user blocks table.
+      end: Column header for the block end date in the user blocks table.
+      status: Column header for the block status in the user blocks table.
+    navigation:
+      all_blocks: Navigation link to view all user blocks.
+      blocks_on_me: Navigation link to view blocks placed on the current user.
+      blocks_on_user_html: Navigation link to view blocks placed on a specific user. %{user} is the username as a link.
+      blocks_by_me: Navigation link to view blocks placed by the current user.
+      blocks_by_user_html: Navigation link to view blocks placed by a specific user. %{user} is the username as a link.
+      block: Navigation link to a specific block. %{id} is the block ID.
+      new_block: Navigation link to create a new user block.
+  user_mutes:
+    index:
+      title: Page title for the muted users list.
+      my_muted_users: Heading for the muted users list.
+      you_have_muted_n_users:
+        one: Singular count of muted users. %{count} is the number.
+        other: Plural count of muted users. %{count} is the number.
+      user_mute_explainer: Explanation of what muting a user does.
+      user_mute_admins_and_moderators: Note that admins and moderators can be muted but their messages won't be filtered.
+      table:
+        thead:
+          muted_user: Column header for the muted user in the muted users table.
+          actions: Column header for actions in the muted users table.
+        tbody:
+          unmute: Button label to unmute a user in the muted users table.
+          send_message: Button label to send a message to a muted user.
+    create:
+      notice: Flash message shown after successfully muting a user. %{name} is the username.
+      error: Flash message shown when a user could not be muted. %{name} is the username, %{full_message} is the error.
+    destroy:
+      notice: Flash message shown after successfully unmuting a user. %{name} is the username.
+      error: Flash message shown when a user could not be unmuted.
+  notes:
+    index:
+      title: Page title for the notes submitted or commented on by a user. %{user} is the username.
+      heading: Heading for the user notes page. %{user} is the username.
+      subheading_html: Subheading with links to filter by submitted or commented notes. %{submitted} and %{commented} are links, %{user} is the username.
+      subheading_submitted: Link text for the 'submitted' filter in the notes subheading.
+      subheading_commented: Link text for the 'commented on' filter in the notes subheading.
+      no_notes: Message shown when there are no notes to display.
+      id: Column header for the note ID in the notes table.
+      creator: Column header for the note creator in the notes table.
+      description: Column header for the note description in the notes table.
+      created_at: Column header for the note creation date in the notes table.
+      last_changed: Column header for the date the note was last changed in the notes table.
+      apply: Button label to apply the status filter on the notes page.
+      all: Option label to show all notes regardless of status.
+      open: Option label to show only unresolved notes.
+      closed: Option label to show only resolved notes.
+      hidden: Option label to show only hidden notes (moderators only).
+      status: Label for the status filter on the notes page.
+    show:
+      title: Page title for a note detail page. %{id} is the note ID.
+      description: Label for the description section on the note detail page.
+      open_title: Heading for an unresolved note. %{note_name} is the note ID.
+      closed_title: Heading for a resolved note. %{note_name} is the note ID.
+      hidden_title: Heading for a hidden note. %{note_name} is the note ID.
+      description_when_author_is_deleted: Text shown as the author name when the note author's account has been deleted.
+      description_when_there_is_no_opening_comment: Text shown as the description when the note has no opening comment.
+      event_opened_by_html: Attribution line for when a note was created by a logged-in user. %{user} is the username, %{time_ago} is the relative time.
+      event_opened_by_anonymous_html: Attribution line for when a note was created by an anonymous user. %{time_ago} is the relative time.
+      event_commented_by_html: Attribution line for a comment on a note by a logged-in user. %{user} is the username, %{time_ago} is the relative time.
+      event_commented_by_anonymous_html: Attribution line for a comment on a note by an anonymous user. %{time_ago} is the relative time.
+      event_closed_by_html: Attribution line for when a note was resolved by a logged-in user. %{user} is the username, %{time_ago} is the relative time.
+      event_closed_by_anonymous_html: Attribution line for when a note was resolved by an anonymous user. %{time_ago} is the relative time.
+      event_reopened_by_html: Attribution line for when a note was reactivated by a logged-in user. %{user} is the username, %{time_ago} is the relative time.
+      event_reopened_by_anonymous_html: Attribution line for when a note was reactivated by an anonymous user. %{time_ago} is the relative time.
+      event_hidden_by_html: Attribution line for when a note was hidden by a moderator. %{user} is the moderator's username, %{time_ago} is the relative time.
+      report: Link text to report a note.
+      coordinates_html: Format for displaying the note's coordinates. %{latitude} and %{longitude} are the values.
+      anonymous_warning: Warning shown when a note includes comments from anonymous users.
+      discussion: Section heading for the discussion/comments on a note.
+      subscribe: Button label to subscribe to updates for a note.
+      unsubscribe: Button label to unsubscribe from updates for a note.
+      hide: Button label to hide a note (moderators only).
+      resolve: Button label to resolve/close a note.
+      reactivate: Button label to reactivate/reopen a note.
+      comment_and_resolve: Button label to add a comment and resolve a note at the same time.
+      comment: Button label to add a comment to a note.
+      log_in_to_comment: Message shown to logged-out users prompting them to log in to comment.
+      report_link_html: Message with a link to report a note containing sensitive information. %{link} is the report link.
+      other_problems_resolve: Advice to resolve a note with a comment for problems other than sensitive information.
+      other_problems_resolved: Advice that resolving is sufficient for problems other than sensitive information.
+      disappear_date_html: Message showing when a resolved note will be automatically removed from the map. %{disappear_in} is the relative time.
+    new:
+      title: Page title for the new note page.
+      intro: Introductory text on the new note page explaining how to add a note.
+      anonymous_warning_html: Warning shown to logged-out users on the new note page. %{log_in} and %{sign_up} are links.
+      anonymous_warning_log_in: Link text for the 'log in' link in the anonymous note warning.
+      anonymous_warning_sign_up: Link text for the 'sign up' link in the anonymous note warning.
+      counter_warning_html: Message shown to users who have posted many anonymous notes, encouraging them to create an account. %{x_anonymous_notes}, %{contribute_by_yourself}, %{community_can_help} are formatted strings.
+      x_anonymous_notes:
+        one: Singular count of anonymous notes in the counter warning. %{count} is the number.
+        other: Plural count of anonymous notes in the counter warning. %{count} is the number.
+      counter_warning_guide_link:
+        text: Link text for the 'contribute by yourself' link in the anonymous note counter warning.
+        url: URL for the beginners' guide, used in the anonymous note counter warning.
       counter_warning_forum_link:
-        url: '{{Optional}}'
+        text: Link text for the 'community can help you' link in the anonymous note counter warning.
+        url: URL for the OHM forum, used in the anonymous note counter warning.
+      advice: Advice text on the new note page about keeping notes public and not entering personal information.
+      add: Button label to submit a new note.
+    new_readonly:
+      title: Page title for the new note page when the API is in read-only mode.
+      warning: Warning message shown when new notes cannot be created because the API is in read-only mode.
+    notes_paging_nav:
+      showing_page: Text showing the current page number in the notes pagination. %{page} is the page number.
+      next: Link text for the next page in the notes pagination.
+      previous: Link text for the previous page in the notes pagination.
+    not_found_message:
+      sorry: Message shown when a note cannot be found. %{id} is the note ID.
   javascripts:
-    close: '{{identical|Close}}'
+    close: Accessible label for close buttons throughout the site.
+    share:
+      title: Title for the share panel.
+      view_larger_map: Link text to view a larger version of an embedded map.
+      export_failed_title: Title for the map export failure notification.
+      filename: Default filename (without extension) for downloaded map images.
+    embed:
+      report_problem: Link text to report a problem, shown in embedded maps.
+    legend:
+      title: Title for the map legend panel.
+      tooltip: Tooltip for the map legend button.
+      tooltip_disabled: Tooltip for the map legend button when no legend is available for the current layer.
     map:
+      navigation_control:
+        zoom_in: Accessible label for the zoom in button in the map navigation control.
+        zoom_out: Accessible label for the zoom out button in the map navigation control.
+      geolocate_control:
+        find_my_location: Accessible label for the geolocate/find my location button.
+        location_not_available: Message shown when geolocation is not available.
+        metersPopup:
+          one: Geolocation accuracy popup when within one meter of the point. %{count} is the number.
+          other: Geolocation accuracy popup when within multiple meters of the point. %{count} is the number.
+        feetPopup:
+          one: Geolocation accuracy popup when within one foot of the point. %{count} is the number.
+          other: Geolocation accuracy popup when within multiple feet of the point. %{count} is the number.
+      zoom:
+        in: Accessible label for the zoom in button.
+        out: Accessible label for the zoom out button.
+      locate:
+        title: Tooltip for the locate/show my location button.
+        metersPopup:
+          one: Location accuracy popup when within one meter of the point. %{count} is the number.
+          other: Location accuracy popup when within multiple meters of the point. %{count} is the number.
+        feetPopup:
+          one: Location accuracy popup when within one foot of the point. %{count} is the number.
+          other: Location accuracy popup when within multiple feet of the point. %{count} is the number.
       base:
-        woodblock: Name for a map style layer simulating [[w:Woodblock printing|(wood)block
-          printing]] technique / ancient woodblock maps.
-        cyclosm: '{{optional}}'
-        shortbread: '{{Optional}}'
-        openmaptiles_osm: '{{Optional}}'
-      copyright_text: '{{optional}}'
-      cyclosm_name: '{{optional}}'
-      tracestrack: This is the name of a company. See https://wiki.openstreetmap.org/wiki/Tracestrack
-      openmaptiles_name: '{{Optional}}'
-      maptiler_name: '{{Optional}}'
+        historical: Name of the Historical map layer in the layer switcher.
+        woodblock: Name of the Woodblock map layer in the layer switcher. Do not translate 'Woodblock' if it is a proper name for this style.
+        japanesescroll: Name of the Japanese Scroll map layer in the layer switcher.
+        railway: Name of the Railway map layer in the layer switcher.
+        standard: Name of the Standard map layer in the layer switcher.
+        cyclosm: Name of the CyclOSM map layer in the layer switcher. Do not translate 'CyclOSM'.
+        cycle_map: Name of the Cycle Map layer in the layer switcher.
+        transport_map: Name of the Transport Map layer in the layer switcher.
+        tracestracktop_topo: Name of the Tracestrack Topo map layer in the layer switcher.
+        hot: Name of the Humanitarian map layer in the layer switcher.
+        shortbread: Name of the Shortbread map layer in the layer switcher. Do not translate 'Shortbread' if it is a proper name for this style.
+        openmaptiles_osm: Name of the MapTiler OMT map layer in the layer switcher.
+      layers:
+        header: Heading for the map layers panel.
+        notes: Label for the map notes overlay toggle in the layers panel.
+        data: Label for the map data overlay toggle in the layers panel.
+        gps: Label for the public GPS traces overlay toggle in the layers panel.
+        overlays: Label for the overlays section in the layers panel.
+        title: Accessible title for the layers panel button.
+      copyright_text: Copyright notice shown on the map. %{copyright_link} is the copyright holder as a link.
+      openstreetmap_contributors: Link text for OpenStreetMap contributors in the map copyright notice.
+      cc0_text: CC0 public domain notice shown on the map. %{copyright_link} is a link.
+      openhistoricalmap_contributors: Short name for OpenHistoricalMap contributors used in the map copyright notice.
+      make_a_donation: Link text for the donation link in the map attribution.
+      website_and_api_terms: Link text for the website and API terms link in the map attribution.
+      cyclosm_credit: Credit line for the CyclOSM tile layer. %{cyclosm_link} and %{osm_france_link} are links.
+      cyclosm_name: Name of CyclOSM used as link text in the tile credit.
+      osm_france: Name of OpenStreetMap France used as link text in the tile credit.
+      thunderforest_credit: Credit line for Thunderforest tile layers. %{thunderforest_link} is a link.
+      andy_allan: Name of Andy Allan used as link text in the Thunderforest tile credit.
+      tracestrack_credit: Credit line for the Tracestrack tile layer. %{tracestrack_link} is a link.
+      tracestrack: Name of Tracestrack used as link text in the tile credit. Do not translate.
+      hotosm_credit: Credit line for the Humanitarian OSM tile layer. %{hotosm_link} and %{osm_france_link} are links.
+      hotosm_name: Name of the Humanitarian OpenStreetMap Team used as link text in the tile credit.
+      openmaptiles_credit: Credit line for the OpenMapTiles vector tile layer. %{openmaptiles_link} and %{maptiler_link} are links.
+      openmaptiles_name: Name of OpenMapTiles used as link text in the tile credit. Do not translate.
+      maptiler_name: Name of MapTiler used as link text in the tile credit. Do not translate.
+    site:
+      edit_tooltip: Tooltip for the edit button on the map.
+      edit_disabled_tooltip: Tooltip for the edit button when the user needs to zoom in to edit.
+      createnote_tooltip: Tooltip for the add note button on the map.
+      createnote_disabled_tooltip: Tooltip for the add note button when the user needs to zoom in.
+      queryfeature_tooltip: Tooltip for the query features button on the map.
+      queryfeature_disabled_tooltip: Tooltip for the query features button when the user needs to zoom in.
+    profile:
+      social_link_n: Accessible label for a social profile link input. %{n} is the link number.
+      remove_social_link_n: Accessible label for the button to remove a social profile link. %{n} is the link number.
+    edit_help: Help text shown when hovering over the edit button, instructing the user to zoom in first.
+    directions:
+      distance_in_units:
+        m: Distance formatted in meters. %{distance} is the numeric value.
+        km: Distance formatted in kilometers. %{distance} is the numeric value.
+        ft: Distance formatted in feet. %{distance} is the numeric value.
+        yd: Distance formatted in yards. %{distance} is the numeric value.
+        mi: Distance formatted in miles. %{distance} is the numeric value.
+      errors:
+        no_route: Error message shown when no route can be found between the two points.
+        no_place:
+          title: Title for the error shown when a place cannot be found for directions.
+          body: Body text for the error shown when a place cannot be found. %{place} is the search term.
+      instructions:
+        continue_without_exit: Routing instruction to continue on a road. %{name} is the road name.
+        slight_right_without_exit: Routing instruction to take a slight right. %{name} is the road name.
+        offramp_right: Routing instruction to take the ramp on the right.
+        offramp_right_with_exit: Routing instruction to take a numbered exit on the right. %{exit} is the exit number.
+        offramp_right_with_exit_name: Routing instruction to take a numbered exit on the right onto a named road. %{exit} is the exit number, %{name} is the road name.
+        offramp_right_with_exit_directions: Routing instruction to take a numbered exit on the right towards a destination. %{exit} is the exit number, %{directions} is the destination.
+        offramp_right_with_exit_name_directions: Routing instruction to take a numbered exit on the right onto a named road towards a destination. %{exit}, %{name}, %{directions} are the values.
+        offramp_right_with_name: Routing instruction to take the ramp on the right onto a named road. %{name} is the road name.
+        offramp_right_with_directions: Routing instruction to take the ramp on the right towards a destination. %{directions} is the destination.
+        offramp_right_with_name_directions: Routing instruction to take the ramp on the right onto a named road towards a destination. %{name} and %{directions} are the values.
+        onramp_right_without_exit: Routing instruction to turn right on the ramp onto a named road. %{name} is the road name.
+        onramp_right_with_directions: Routing instruction to turn right onto the ramp towards a destination. %{directions} is the destination.
+        onramp_right_with_name_directions: Routing instruction to turn right on the ramp onto a named road towards a destination. %{name} and %{directions} are the values.
+        onramp_right_without_directions: Routing instruction to turn right onto the ramp.
+        onramp_right: Routing instruction to turn right onto the ramp.
+        endofroad_right_without_exit: Routing instruction to turn right at the end of the road. %{name} is the road name.
+        merge_right_without_exit: Routing instruction to merge right. %{name} is the road name.
+        fork_right_without_exit: Routing instruction to take the right fork. %{name} is the road name.
+        turn_right_without_exit: Routing instruction to turn right. %{name} is the road name.
+        sharp_right_without_exit: Routing instruction to take a sharp right. %{name} is the road name.
+        uturn_without_exit: Routing instruction to make a U-turn. %{name} is the road name.
+        sharp_left_without_exit: Routing instruction to take a sharp left. %{name} is the road name.
+        turn_left_without_exit: Routing instruction to turn left. %{name} is the road name.
+        offramp_left: Routing instruction to take the ramp on the left.
+        offramp_left_with_exit: Routing instruction to take a numbered exit on the left. %{exit} is the exit number.
+        offramp_left_with_exit_name: Routing instruction to take a numbered exit on the left onto a named road. %{exit} is the exit number, %{name} is the road name.
+        offramp_left_with_exit_directions: Routing instruction to take a numbered exit on the left towards a destination. %{exit} and %{directions} are the values.
+        offramp_left_with_exit_name_directions: Routing instruction to take a numbered exit on the left onto a named road towards a destination. %{exit}, %{name}, %{directions} are the values.
+        offramp_left_with_name: Routing instruction to take the ramp on the left onto a named road. %{name} is the road name.
+        offramp_left_with_directions: Routing instruction to take the ramp on the left towards a destination. %{directions} is the destination.
+        offramp_left_with_name_directions: Routing instruction to take the ramp on the left onto a named road towards a destination. %{name} and %{directions} are the values.
+        onramp_left_without_exit: Routing instruction to turn left on the ramp onto a named road. %{name} is the road name.
+        onramp_left_with_directions: Routing instruction to turn left onto the ramp towards a destination. %{directions} is the destination.
+        onramp_left_with_name_directions: Routing instruction to turn left on the ramp onto a named road towards a destination. %{name} and %{directions} are the values.
+        onramp_left_without_directions: Routing instruction to turn left onto the ramp.
+        onramp_left: Routing instruction to turn left onto the ramp.
+        endofroad_left_without_exit: Routing instruction to turn left at the end of the road. %{name} is the road name.
+        merge_left_without_exit: Routing instruction to merge left. %{name} is the road name.
+        fork_left_without_exit: Routing instruction to take the left fork. %{name} is the road name.
+        slight_left_without_exit: Routing instruction to take a slight left. %{name} is the road name.
+        via_point_without_exit: Routing instruction label for a via/waypoint.
+        follow_without_exit: Routing instruction to follow a road. %{name} is the road name.
+        roundabout_without_exit: Routing instruction to take the exit at a roundabout. %{name} is the road name.
+        leave_roundabout_without_exit: Routing instruction to leave the roundabout. %{name} is the road name.
+        stay_roundabout_without_exit: Routing instruction to stay on the roundabout. %{name} is the road name.
+        start_without_exit: Routing instruction for the start of the route. %{name} is the road name.
+        destination_without_exit: Routing instruction indicating the destination has been reached.
+        against_oneway_without_exit: Routing instruction to go against a one-way street. %{name} is the road name.
+        end_oneway_without_exit: Routing instruction for the end of a one-way street. %{name} is the road name.
+        roundabout_with_exit: Routing instruction to take a numbered exit at a roundabout onto a named road. %{exit} is the exit number, %{name} is the road name.
+        roundabout_with_exit_ordinal: Routing instruction to take an ordinally-numbered exit at a roundabout. %{exit} is the ordinal (e.g. '1st'), %{name} is the road name.
+        exit_roundabout: Routing instruction to exit the roundabout. %{name} is the road name.
+        ferry_without_exit: Routing instruction to take a ferry. %{name} is the ferry name.
+        unnamed: Placeholder name used in routing instructions when a road has no name.
+        exit_counts:
+          first: Ordinal label for the first roundabout exit.
+          second: Ordinal label for the second roundabout exit.
+          third: Ordinal label for the third roundabout exit.
+          fourth: Ordinal label for the fourth roundabout exit.
+          fifth: Ordinal label for the fifth roundabout exit.
+          sixth: Ordinal label for the sixth roundabout exit.
+          seventh: Ordinal label for the seventh roundabout exit.
+          eighth: Ordinal label for the eighth roundabout exit.
+          ninth: Ordinal label for the ninth roundabout exit.
+          tenth: Ordinal label for the tenth roundabout exit.
     query:
-      suffix_format: |-
-        {{Optional|Only translate if the customary format for indicating the date range associated with something uses different punctuation.}}
-
-        {{Identical|Date suffix format}}
+      node: Label for a node result in the feature query panel.
+      way: Label for a way result in the feature query panel.
+      relation: Label for a relation result in the feature query panel.
+      nothing_found: Message shown in the feature query panel when no features are found at the clicked location.
+      error: Error message shown in the feature query panel when the server returns an error. %{server} is the server name, %{error} is the error message.
+      timeout: Error message shown in the feature query panel when the server times out. %{server} is the server name.
+      suffix_format: Format for appending historical date information to a feature name in query results. %{dates} is the date range. See also geocoder.search_osm_nominatim.suffix_format.
     element:
-      wikipedia: '{{Optional}}'
+      wikipedia: Link text for Wikipedia links shown in the tag details panel for wikipedia=* tags.
+    context:
+      directions_from: Context menu item to get directions from the clicked location.
+      directions_to: Context menu item to get directions to the clicked location.
+      add_note: Context menu item to add a map note at the clicked location.
+      show_address: Context menu item to show the address of the clicked location.
+      query_features: Context menu item to query features at the clicked location.
+      centre_map: Context menu item to centre the map on the clicked location.
+      scroll_to_changeset: Context menu item to scroll the changeset list to the relevant changeset.
+    home:
+      marker_title: Title for the home location marker on the map.
+      not_set: Message shown in the home location popup when no home location is set.
+    heatmap:
+      tooltip:
+        no_contributions: Tooltip shown on a contribution calendar cell with no contributions. %{date} is the date.
+        contributions:
+          one: Tooltip shown on a contribution calendar cell with one contribution. %{count} is the number, %{date} is the date.
+          other: Tooltip shown on a contribution calendar cell with multiple contributions. %{count} is the number, %{date} is the date.
+    remote_edit:
+      failed:
+        title: Title for the remote editing failure notification.
+        body: Body text for the remote editing failure notification, instructing the user to check JOSM/Merkaartor.
     edit:
       id_not_configured:
-        title: |-
-          The term '''iD''' (with a lowercase initial and a capital second letter) is the actual name of an online map editor for OpenStreepMap or similar map editing projects.
-          : ''It is '''not''' meaning or abbreviating "identifier".'' Do not change it!
-...
+        title: Title for the notification shown when iD editor has not been configured.
+        body: Body text for the iD not configured notification, pointing to CONFIGURE.md.
+  redactions:
+    edit:
+      heading: Heading for the edit redaction page.
+      title: Page title for the edit redaction page.
+    index:
+      empty: Message shown when there are no redactions to display.
+      heading: Heading for the redactions list page.
+      title: Page title for the redactions list page.
+      new: Link text to create a new redaction.
+    new:
+      heading: Heading for the create new redaction page.
+      title: Page title for the create new redaction page.
+    show:
+      description: Label for the description field on the redaction detail page.
+      heading: Heading for the redaction detail page. %{title} is the redaction title.
+      title: Page title for the redaction detail page.
+      user: Label for the creator field on the redaction detail page.
+      edit: Link text to edit the redaction.
+      destroy: Link text to delete the redaction.
+      confirm: Confirmation prompt before deleting a redaction.
+    create:
+      flash: Flash message shown after successfully creating a redaction.
+    update:
+      flash: Flash message shown after successfully saving changes to a redaction.
+    destroy:
+      not_empty: Error message shown when trying to delete a redaction that still has redacted versions.
+      flash: Flash message shown after successfully deleting a redaction.
+      error: Flash message shown when there was an error deleting a redaction.
+  validations:
+    leading_whitespace: Validation error message shown when a field value has leading whitespace.
+    trailing_whitespace: Validation error message shown when a field value has trailing whitespace.
+    invalid_characters: Validation error message shown when a field value contains invalid characters.
+    url_characters: Validation error message shown when a field value contains special URL characters. %{characters} is the list of problematic characters.
+  diary_comments:
+    new:
+      heading: Heading on the add diary comment confirmation page.
+  doorkeeper:
+    errors:
+      messages:
+        account_selection_required: Error message shown when the authorization server requires the user to select an account.
+        consent_required: Error message shown when the authorization server requires end-user consent.
+        interaction_required: Error message shown when the authorization server requires end-user interaction.
+        login_required: Error message shown when the authorization server requires end-user authentication.
+    flash:
+      applications:
+        create:
+          notice: Flash message shown after successfully registering a new OAuth application.
+    openid_connect:
+      errors:
+        messages:
+          auth_time_from_resource_owner_not_configured: Error message shown when the auth_time_from_resource_owner configuration is missing.
+          reauthenticate_resource_owner_not_configured: Error message shown when the reauthenticate_resource_owner configuration is missing.
+          resource_owner_from_access_token_not_configured: Error message shown when the resource_owner_from_access_token configuration is missing.
+          select_account_for_resource_owner_not_configured: Error message shown when the select_account_for_resource_owner configuration is missing.
+          subject_not_configured: Error message shown when the subject configuration is missing, preventing ID token generation.
+    scopes:
+      address: Description of the 'address' OpenID Connect scope.
+      email: Description of the 'email' OpenID Connect scope.
+      openid: Description of the 'openid' scope.
+      phone: Description of the 'phone' OpenID Connect scope.
+      profile: Description of the 'profile' OpenID Connect scope.


### PR DESCRIPTION
Complete `config/locales/qqq.yml` with descriptions for all 3,074 translatable strings, covering context, variable placeholders, and usage notes to assist translators.

### Description

`qqq.yml` is a special TranslateWiki file that provides documentation hints for translators. It is not a translation itself and is not managed by TranslateWiki — it lives in the source repo and is read by TranslateWiki to show context to translators working on any of the supported languages.

Previously the file was largely incomplete. This PR adds descriptions for all 3,074 translatable strings in `en.yml`, covering:

- Where and how each string appears in the UI
- Variable placeholders (`%{name}`, `{{name}}`) with explanations of what each contains
- Strings that should not be translated (e.g. language names, proper nouns)

### How has this been tested?

Verified with a Ruby script that all 3,074 `en.yml` leaf keys have a corresponding `qqq.yml` entry:

EN leaf keys: 3074
QQQ leaf keys: 3239
Missing: 0

The higher QQQ count reflects plural form documentation entries (`one`/`other`/`few` etc.) that are documented separately.